### PR TITLE
Fix metric naming consistency feed_sources -> cache_sources

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -111,7 +111,8 @@ func (cache Cache) FetchTwts(conf *Config, archive Archiver, feeds types.Feeds) 
 	// max parallel http fetchers
 	var fetchers = make(chan struct{}, maxfetchers)
 
-	metrics.Gauge("feed", "sources").Set(float64(len(feeds)))
+	metrics.Gauge("cache", "sources").Set(float64(len(feeds)))
+
 	for feed := range feeds {
 		wg.Add(1)
 		fetchers <- struct{}{}

--- a/internal/server.go
+++ b/internal/server.go
@@ -202,10 +202,10 @@ func (s *Server) setupMetrics() {
 		},
 	)
 
-	// feed sources
+	// feed cache sources
 	metrics.NewGauge(
-		"feed", "sources",
-		"Number of feed sources being fetched",
+		"cache", "sources",
+		"Number of feed sources being fetched by the global feed cache",
 	)
 
 	// feed cache size


### PR DESCRIPTION
##### Summary

Just some inconsistency I noticed.

##### Component Name

- area/backend

##### Test Plan

It builds. #testinprod

##### Additional Information