### PR TITLE
Add unit tests for types.Twt.Subject() and fix the regex

### DIFF
--- a/types/twt_test.go
+++ b/types/twt_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"testing"
+  "time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubject(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("String", func(t *testing.T) {
+		//f := Feed{Nick: "prologic", URL: "https://twtxt.net/user/prologic/twtxt.txt"}
+		//assert.Equal("@<prologic https://twtxt.net/user/prologic/twtxt.txt>", f.String())
+    // a := [5][2]string{{"@antonio (#iuf98kd) nice post!","(#iuf98kd)"}, {"",""}, {"",""}, {"",""},{"",""}}
+
+    cases := [][]string{
+		              []string{"@antonio (#iuf98kd) nice post!", "(#iuf98kd)"},
+		              []string{"@prologic (re nice jacket)", "(re nice jacket)"},
+		              []string{"(re nice jacket)", ""},
+                  []string{"Best time of the week (aka weekend)", ""},
+                  []string{"@antonio (re weekend) I like the weekend too. (is the best)", "(re weekend)"},
+                  []string{"tomorrow (sat) (sun) (moon)",""},
+                  []string{"@antonio2 @antonio (#j3hyzva) testte #test1 (s) and #test2 (s) and more text","(#j3hyzva)"},
+                  []string{"@antonio3 @antonio (#j3hyzva) testing again", "(#j3hyzva)"},
+                  []string{"(#veryfunny) you are funny",""},
+                  []string{"#having fun (satruday) another day",""},
+	               }
+
+    for i := 0; i < len(cases); i++ {
+      twt := Twt{Twter: Twter{}, Text: cases[i][0], Created: time.Now()}
+      sub := twt.Subject()
+      assert.Equal(cases[i][1], sub)
+    }
+	})
+}

--- a/types/twt_test.go
+++ b/types/twt_test.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"testing"
-  "time"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -11,28 +11,49 @@ func TestSubject(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("String", func(t *testing.T) {
-		//f := Feed{Nick: "prologic", URL: "https://twtxt.net/user/prologic/twtxt.txt"}
-		//assert.Equal("@<prologic https://twtxt.net/user/prologic/twtxt.txt>", f.String())
-    // a := [5][2]string{{"@antonio (#iuf98kd) nice post!","(#iuf98kd)"}, {"",""}, {"",""}, {"",""},{"",""}}
+		testCases := []struct {
+			Text    string
+			Subject string
+		}{
+			{
+				Text:    "@<antonio bla.com> (#iuf98kd) nice post!",
+				Subject: "(#iuf98kd)",
+			}, {
+				Text:    "@<prologic bla.com> (re nice jacket)",
+				Subject: "(re nice jacket)",
+			}, {
+				Text:    "(re nice jacket)",
+				Subject: "(re nice jacket)",
+			}, {
+				Text:    "Best time of the week (aka weekend)",
+				Subject: "",
+			}, {
+				Text:    "@<antonio bla.com> (re weekend) I like the weekend too. (is the best)",
+				Subject: "(re weekend)",
+			}, {
+				Text:    "tomorrow (sat) (sun) (moon)",
+				Subject: "",
+			}, {
+				Text:    "@<antonio2 bla.com> @<antonio bla.com> (#j3hyzva) testte #test1 (s) and #test2 (s) and more text",
+				Subject: "(#j3hyzva)",
+			}, {
+				Text:    "@<antonio3 bla.com> @<antonio bla.com> (#j3hyzva) testing again",
+				Subject: "(#j3hyzva)",
+			}, {
+				Text:    "(#veryfunny) you are funny",
+				Subject: "(#veryfunny)",
+			}, {
+				Text:    "#having fun (satruday) another day",
+				Subject: "",
+			}, {
+				Text:    "@<antonio3 bla.com> not funny dude",
+				Subject: "",
+			},
+		}
 
-    cases := [][]string{
-		              []string{"@<antonio bla.com> (#iuf98kd) nice post!", "(#iuf98kd)"},
-		              []string{"@<prologic bla.com> (re nice jacket)", "(re nice jacket)"},
-		              []string{"(re nice jacket)", ""},
-                  []string{"Best time of the week (aka weekend)", ""},
-                  []string{"@<antonio bla.com> (re weekend) I like the weekend too. (is the best)", "(re weekend)"},
-                  []string{"tomorrow (sat) (sun) (moon)",""},
-                  []string{"@<antonio2 bla.com> @<antonio bla.com> (#j3hyzva) testte #test1 (s) and #test2 (s) and more text","(#j3hyzva)"},
-                  []string{"@<antonio3 bla.com> @<antonio bla.com> (#j3hyzva) testing again", "(#j3hyzva)"},
-                  []string{"(#veryfunny) you are funny",""},
-                  []string{"#having fun (satruday) another day",""},
-                  []string{"@<antonio3 bla.com> not funny dude",""},
-	               }
-
-    for i := 0; i < len(cases); i++ {
-      twt := Twt{Twter: Twter{}, Text: cases[i][0], Created: time.Now()}
-      sub := twt.Subject()
-      assert.Equal(cases[i][1], sub)
-    }
+		for _, testCase := range testCases {
+			twt := Twt{Twter: Twter{}, Text: testCase.Text, Created: time.Now()}
+			assert.Equal(testCase.Subject, twt.Subject())
+		}
 	})
 }

--- a/types/twt_test.go
+++ b/types/twt_test.go
@@ -43,7 +43,7 @@ func TestSubject(t *testing.T) {
 				Text:    "(#veryfunny) you are funny",
 				Subject: "(#veryfunny)",
 			}, {
-				Text:    "#having fun (satruday) another day",
+				Text:    "#having fun (saturday) another day",
 				Subject: "",
 			}, {
 				Text:    "@<antonio3 bla.com> not funny dude",

--- a/types/twt_test.go
+++ b/types/twt_test.go
@@ -16,16 +16,17 @@ func TestSubject(t *testing.T) {
     // a := [5][2]string{{"@antonio (#iuf98kd) nice post!","(#iuf98kd)"}, {"",""}, {"",""}, {"",""},{"",""}}
 
     cases := [][]string{
-		              []string{"@antonio (#iuf98kd) nice post!", "(#iuf98kd)"},
-		              []string{"@prologic (re nice jacket)", "(re nice jacket)"},
+		              []string{"@<antonio bla.com> (#iuf98kd) nice post!", "(#iuf98kd)"},
+		              []string{"@<prologic bla.com> (re nice jacket)", "(re nice jacket)"},
 		              []string{"(re nice jacket)", ""},
                   []string{"Best time of the week (aka weekend)", ""},
-                  []string{"@antonio (re weekend) I like the weekend too. (is the best)", "(re weekend)"},
+                  []string{"@<antonio bla.com> (re weekend) I like the weekend too. (is the best)", "(re weekend)"},
                   []string{"tomorrow (sat) (sun) (moon)",""},
-                  []string{"@antonio2 @antonio (#j3hyzva) testte #test1 (s) and #test2 (s) and more text","(#j3hyzva)"},
-                  []string{"@antonio3 @antonio (#j3hyzva) testing again", "(#j3hyzva)"},
+                  []string{"@<antonio2 bla.com> @<antonio bla.com> (#j3hyzva) testte #test1 (s) and #test2 (s) and more text","(#j3hyzva)"},
+                  []string{"@<antonio3 bla.com> @<antonio bla.com> (#j3hyzva) testing again", "(#j3hyzva)"},
                   []string{"(#veryfunny) you are funny",""},
                   []string{"#having fun (satruday) another day",""},
+                  []string{"@<antonio3 bla.com> not funny dude",""},
 	               }
 
     for i := 0; i < len(cases); i++ {


### PR DESCRIPTION


##### Summary
Adds test to Subject() method in twt.go

##### Component Name
twt_test.go

##### Test Plan
```
@antonio (#iuf98kd) nice post! _expected return_ (#iuf98kd)
@prologic (re nice jacket) _expected return_ (re nice jacket),
(re nice jacket) _expected return_ is empty
Best time of the week (aka weekend) _expected return_ is empty
@antonio (re weekend) I like the weekend too. (is the best) _expected return_ (re weekend)
tomorrow (sat) (sun) (moon) _expected return_ is empty
@antonio2 @antonio (#j3hyzva) testte #test1 (s) and #test2 (s) and more text _expected return_ (#j3hyzva)
@antonio3 @antonio (#j3hyzva) testing again _expected return_ (#j3hyzva)
(#veryfunny) you are funny _expected return_ is empty
#having fun (satruday) another day _expected return_ is empty
```
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
