### PR TITLE
feat: Add profile endpoint to api

### DIFF
--- a/docs/_posts/2020-08-05-api.md
+++ b/docs/_posts/2020-08-05-api.md
@@ -125,3 +125,14 @@ __NOTE:__ No authentication is required for this endpoint.
   - `400 Bad Request` on parsing invalid or bad requests.
   - `401 Unauthorized` with "Invalid Credentials" on unsuccessful auth
   - `500 Internal Server Error` if an intenral error occurrs.
+
+
+### /profile/:nick
+
+- Purpose: To get the profile of user/feed
+- Method: `GET`
+- Request: _none_
+- Response: 
+  - `200k OK` with `{"profile": ..., "links": ..., "alternatives": ... }`. See `types.ProfileResponse` for more info
+  - `404 Not found` on user/feed not found
+  - `500 Internal Server Error` if an intenral error occurrs.

--- a/internal/api.go
+++ b/internal/api.go
@@ -70,6 +70,7 @@ func (a *API) initRoutes() {
 	router.POST("/follow", a.isAuthorized(a.FollowEndpoint()))
 	router.POST("/timeline", a.isAuthorized(a.TimelineEndpoint()))
 	router.POST("/upload", a.isAuthorized(a.UploadMediaEndpoint()))
+	router.GET("/profile/:nick", a.isAuthorized(a.ProfileEndpoint()))
 	router.POST("/discover", a.DiscoverEndpoint())
 }
 

--- a/internal/api.go
+++ b/internal/api.go
@@ -612,7 +612,7 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				return
 			}
-			profile = user.Profile(a.config)
+			profile = user.Profile(a.config.BaseURL)
 		} else if a.db.HasFeed(nick) {
 			feed, err := a.db.GetFeed(nick)
 			if err != nil {
@@ -620,7 +620,7 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				return
 			}
-			profile = feed.Profile(a.config)
+			profile = feed.Profile(a.config.BaseURL)
 		} else {
 			http.Error(w, "User/Feed not found", http.StatusNotFound)
 			return

--- a/internal/api.go
+++ b/internal/api.go
@@ -603,7 +603,7 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 
 		nick = NormalizeUsername(nick)
 
-		var profile Profile
+		var profile types.Profile
 
 		if a.db.HasUser(nick) {
 			user, err := a.db.GetUser(nick)
@@ -612,7 +612,7 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				return
 			}
-			profile = user.Profile()
+			profile = user.Profile(a.config)
 		} else if a.db.HasFeed(nick) {
 			feed, err := a.db.GetFeed(nick)
 			if err != nil {
@@ -620,7 +620,7 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				return
 			}
-			profile = feed.Profile()
+			profile = feed.Profile(a.config)
 		} else {
 			http.Error(w, "User/Feed not found", http.StatusNotFound)
 			return

--- a/internal/api.go
+++ b/internal/api.go
@@ -70,7 +70,7 @@ func (a *API) initRoutes() {
 	router.POST("/follow", a.isAuthorized(a.FollowEndpoint()))
 	router.POST("/timeline", a.isAuthorized(a.TimelineEndpoint()))
 	router.POST("/upload", a.isAuthorized(a.UploadMediaEndpoint()))
-	router.GET("/profile/:nick", a.isAuthorized(a.ProfileEndpoint()))
+	router.GET("/profile/:nick", a.ProfileEndpoint())
 	router.POST("/discover", a.DiscoverEndpoint())
 }
 
@@ -107,6 +107,38 @@ func (a *API) jwtKeyFunc(token *jwt.Token) (interface{}, error) {
 		return nil, fmt.Errorf("There was an error")
 	}
 	return a.config.APISigningKey, nil
+}
+
+func (a *API) getLoggedInUser(r *http.Request) *User {
+	token, err := jwt.Parse(r.Header.Get("Token"), a.jwtKeyFunc)
+	if err != nil {
+		return nil
+	}
+
+	if !token.Valid {
+		return nil
+	}
+
+	claims := token.Claims.(jwt.MapClaims)
+
+	username := claims["username"].(string)
+
+	user, err := a.db.GetUser(username)
+	if err != nil {
+		log.WithError(err).Error("error loading user object")
+		return nil
+	}
+
+	// Every registered new user follows themselves
+	// TODO: Make  this configurable server behaviour?
+	if user.Following == nil {
+		user.Following = make(map[string]string)
+	}
+
+	user.Following[user.Username] = user.URL
+
+	return user
+
 }
 
 func (a *API) isAuthorized(endpoint httprouter.Handle) httprouter.Handle {
@@ -595,6 +627,7 @@ func (a *API) UploadMediaEndpoint() httprouter.Handle {
 // ProfileEndpoint ...
 func (a *API) ProfileEndpoint() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		loggedInUser := a.getLoggedInUser(r)
 		nick := NormalizeUsername(p.ByName("nick"))
 		if nick == "" {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
@@ -613,6 +646,15 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 				return
 			}
 			profile = user.Profile(a.config.BaseURL)
+
+			if loggedInUser == nil {
+				if !user.IsFollowersPubliclyVisible {
+					profile.Followers = map[string]string{}
+				}
+				if !user.IsFollowingPubliclyVisible {
+					profile.Following = map[string]string{}
+				}
+			}
 		} else if a.db.HasFeed(nick) {
 			feed, err := a.db.GetFeed(nick)
 			if err != nil {
@@ -636,6 +678,11 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 		}}
 
 		profileResponse.Alternatives = types.Alternatives{
+			types.Alternative{
+				Type:  "application/atom+xml",
+				Title: fmt.Sprintf("%s local feed", a.config.Name),
+				URL:   fmt.Sprintf("%s/atom.xml", a.config.BaseURL),
+			},
 			types.Alternative{
 				Type:  "text/plain",
 				Title: fmt.Sprintf("%s's Twtxt Feed", profile.Username),

--- a/internal/api.go
+++ b/internal/api.go
@@ -626,7 +626,29 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 			return
 		}
 
-		data, err := json.Marshal(profile)
+		profileResponse := types.ProfileResponse{}
+
+		profileResponse.Profile = profile
+
+		profileResponse.Links = types.Links{types.Link{
+			Href: fmt.Sprintf("%s/webmention", UserURL(profile.URL)),
+			Rel:  "webmention",
+		}}
+
+		profileResponse.Alternatives = types.Alternatives{
+			types.Alternative{
+				Type:  "text/plain",
+				Title: fmt.Sprintf("%s's Twtxt Feed", profile.Username),
+				URL:   profile.URL,
+			},
+			types.Alternative{
+				Type:  "application/atom+xml",
+				Title: fmt.Sprintf("%s's Atom Feed", profile.Username),
+				URL:   fmt.Sprintf("%s/atom.xml", UserURL(profile.URL)),
+			},
+		}
+
+		data, err := json.Marshal(profileResponse)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/blog_handlers.go
+++ b/internal/blog_handlers.go
@@ -189,7 +189,7 @@ func (s *Server) BlogsHandler() httprouter.Handle {
 
 		author = NormalizeUsername(author)
 
-		var profile Profile
+		var profile types.Profile
 
 		if s.db.HasUser(author) {
 			user, err := s.db.GetUser(author)

--- a/internal/blog_handlers.go
+++ b/internal/blog_handlers.go
@@ -134,17 +134,17 @@ func (s *Server) BlogHandler() httprouter.Handle {
 			Keywords:    strings.Join(ks, ", "),
 		}
 		if strings.HasPrefix(twt.Twter.URL, s.config.BaseURL) {
-			ctx.Links = append(ctx.Links, Link{
+			ctx.Links = append(ctx.Links, types.Link{
 				Href: fmt.Sprintf("%s/webmention", UserURL(twt.Twter.URL)),
 				Rel:  "webmention",
 			})
-			ctx.Alternatives = append(ctx.Alternatives, Alternatives{
-				Alternative{
+			ctx.Alternatives = append(ctx.Alternatives, types.Alternatives{
+				types.Alternative{
 					Type:  "text/plain",
 					Title: fmt.Sprintf("%s's Twtxt Feed", twt.Twter.Nick),
 					URL:   twt.Twter.URL,
 				},
-				Alternative{
+				types.Alternative{
 					Type:  "application/atom+xml",
 					Title: fmt.Sprintf("%s's Atom Feed", twt.Twter.Nick),
 					URL:   fmt.Sprintf("%s/atom.xml", UserURL(twt.Twter.URL)),
@@ -220,17 +220,17 @@ func (s *Server) BlogsHandler() httprouter.Handle {
 
 		ctx.Profile = profile
 
-		ctx.Links = append(ctx.Links, Link{
+		ctx.Links = append(ctx.Links, types.Link{
 			Href: fmt.Sprintf("%s/webmention", UserURL(profile.URL)),
 			Rel:  "webmention",
 		})
-		ctx.Alternatives = append(ctx.Alternatives, Alternatives{
-			Alternative{
+		ctx.Alternatives = append(ctx.Alternatives, types.Alternatives{
+			types.Alternative{
 				Type:  "text/plain",
 				Title: fmt.Sprintf("%s's Twtxt Feed", profile.Username),
 				URL:   profile.URL,
 			},
-			Alternative{
+			types.Alternative{
 				Type:  "application/atom+xml",
 				Title: fmt.Sprintf("%s's Atom Feed", profile.Username),
 				URL:   fmt.Sprintf("%s/atom.xml", UserURL(profile.URL)),

--- a/internal/context.go
+++ b/internal/context.go
@@ -15,20 +15,6 @@ import (
 	"github.com/theplant-retired/timezones"
 )
 
-type Link struct {
-	Href string
-	Rel  string
-}
-
-type Alternative struct {
-	Type  string
-	Title string
-	URL   string
-}
-
-type Alternatives []Alternative
-type Links []Link
-
 type Meta struct {
 	Title       string
 	Author      string
@@ -66,8 +52,8 @@ type Context struct {
 
 	Title        string
 	Meta         Meta
-	Links        Links
-	Alternatives Alternatives
+	Links        types.Links
+	Alternatives types.Alternatives
 
 	Twter       types.Twter
 	Twts        types.Twts
@@ -104,8 +90,8 @@ func NewContext(conf *Config, db Store, req *http.Request) *Context {
 			Description: DefaultMetaDescription,
 		},
 
-		Alternatives: Alternatives{
-			Alternative{
+		Alternatives: types.Alternatives{
+			types.Alternative{
 				Type:  "application/atom+xml",
 				Title: fmt.Sprintf("%s local feed", conf.Name),
 				URL:   fmt.Sprintf("%s/atom.xml", conf.BaseURL),

--- a/internal/context.go
+++ b/internal/context.go
@@ -53,7 +53,7 @@ type Context struct {
 	User          *User
 	Tokens        []*Token
 	LastTwt       types.Twt
-	Profile       Profile
+	Profile       types.Profile
 	Authenticated bool
 
 	Error   bool

--- a/internal/conversation_handler.go
+++ b/internal/conversation_handler.go
@@ -120,17 +120,17 @@ func (s *Server) ConversationHandler() httprouter.Handle {
 			Keywords:    strings.Join(ks, ", "),
 		}
 		if strings.HasPrefix(twt.Twter.URL, s.config.BaseURL) {
-			ctx.Links = append(ctx.Links, Link{
+			ctx.Links = append(ctx.Links, types.Link{
 				Href: fmt.Sprintf("%s/webmention", UserURL(twt.Twter.URL)),
 				Rel:  "webmention",
 			})
-			ctx.Alternatives = append(ctx.Alternatives, Alternatives{
-				Alternative{
+			ctx.Alternatives = append(ctx.Alternatives, types.Alternatives{
+				types.Alternative{
 					Type:  "text/plain",
 					Title: fmt.Sprintf("%s's Twtxt Feed", twt.Twter.Nick),
 					URL:   twt.Twter.URL,
 				},
-				Alternative{
+				types.Alternative{
 					Type:  "application/atom+xml",
 					Title: fmt.Sprintf("%s's Atom Feed", twt.Twter.Nick),
 					URL:   fmt.Sprintf("%s/atom.xml", UserURL(twt.Twter.URL)),

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -214,17 +214,18 @@ func (s *Server) ProfileHandler() httprouter.Handle {
 
 		ctx.Profile = profile
 
-		ctx.Links = append(ctx.Links, Link{
+		ctx.Links = append(ctx.Links, types.Link{
 			Href: fmt.Sprintf("%s/webmention", UserURL(profile.URL)),
 			Rel:  "webmention",
 		})
-		ctx.Alternatives = append(ctx.Alternatives, Alternatives{
-			Alternative{
+
+		ctx.Alternatives = append(ctx.Alternatives, types.Alternatives{
+			types.Alternative{
 				Type:  "text/plain",
 				Title: fmt.Sprintf("%s's Twtxt Feed", profile.Username),
 				URL:   profile.URL,
 			},
-			Alternative{
+			types.Alternative{
 				Type:  "application/atom+xml",
 				Title: fmt.Sprintf("%s's Atom Feed", profile.Username),
 				URL:   fmt.Sprintf("%s/atom.xml", UserURL(profile.URL)),
@@ -969,17 +970,17 @@ func (s *Server) PermalinkHandler() httprouter.Handle {
 			Keywords:    strings.Join(ks, ", "),
 		}
 		if strings.HasPrefix(twt.Twter.URL, s.config.BaseURL) {
-			ctx.Links = append(ctx.Links, Link{
+			ctx.Links = append(ctx.Links, types.Link{
 				Href: fmt.Sprintf("%s/webmention", UserURL(twt.Twter.URL)),
 				Rel:  "webmention",
 			})
-			ctx.Alternatives = append(ctx.Alternatives, Alternatives{
-				Alternative{
+			ctx.Alternatives = append(ctx.Alternatives, types.Alternatives{
+				types.Alternative{
 					Type:  "text/plain",
 					Title: fmt.Sprintf("%s's Twtxt Feed", twt.Twter.Nick),
 					URL:   twt.Twter.URL,
 				},
-				Alternative{
+				types.Alternative{
 					Type:  "application/atom+xml",
 					Title: fmt.Sprintf("%s's Atom Feed", twt.Twter.Nick),
 					URL:   fmt.Sprintf("%s/atom.xml", UserURL(twt.Twter.URL)),

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -183,7 +183,7 @@ func (s *Server) ProfileHandler() httprouter.Handle {
 
 		nick = NormalizeUsername(nick)
 
-		var profile Profile
+		var profile types.Profile
 
 		if s.db.HasUser(nick) {
 			user, err := s.db.GetUser(nick)
@@ -1960,7 +1960,7 @@ func (s *Server) ExternalHandler() httprouter.Handle {
 			URL:    url,
 			Avatar: URLForExternalAvatar(s.config, url),
 		}
-		ctx.Profile = Profile{
+		ctx.Profile = types.Profile{
 			Username: nick,
 			TwtURL:   url,
 			URL:      URLForExternalProfile(s.config, nick, url),
@@ -2273,7 +2273,7 @@ func (s *Server) SyndicationHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		var (
 			twts    types.Twts
-			profile Profile
+			profile types.Profile
 			err     error
 		)
 
@@ -2304,7 +2304,7 @@ func (s *Server) SyndicationHandler() httprouter.Handle {
 		} else {
 			twts = s.cache.GetByPrefix(s.config.BaseURL, false)
 
-			profile = Profile{
+			profile = types.Profile{
 				Type:     "Local",
 				Username: s.config.Name,
 				Tagline:  "", // TODO: Maybe Twtxt Pods should have a configurable description?

--- a/internal/models.go
+++ b/internal/models.go
@@ -240,8 +240,8 @@ func (f *Feed) FollowedBy(url string) bool {
 	return ok
 }
 
-func (f *Feed) Profile(baseURL string) Profile {
-	return Profile{
+func (f *Feed) Profile(baseURL string) types.Profile {
+	return types.Profile{
 		Type: "Feed",
 
 		Username: f.Name,
@@ -326,8 +326,8 @@ func (u *User) Sources() types.Feeds {
 	return feeds
 }
 
-func (u *User) Profile(baseURL string) Profile {
-	return Profile{
+func (u *User) Profile(baseURL string) types.Profile {
+	return types.Profile{
 		Type: "User",
 
 		Username: u.Username,

--- a/types/api.go
+++ b/types/api.go
@@ -123,4 +123,7 @@ func NewFollowRequest(r io.Reader) (req FollowRequest, err error) {
 }
 
 type ProfileResponse struct {
+	Profile      Profile      `json:"profile"`
+	Links        Links        `json:"links"`
+	Alternatives Alternatives `json:"alternatives"`
 }

--- a/types/api.go
+++ b/types/api.go
@@ -121,3 +121,6 @@ func NewFollowRequest(r io.Reader) (req FollowRequest, err error) {
 	err = json.Unmarshal(body, &req)
 	return
 }
+
+type ProfileResponse struct {
+}

--- a/types/profile.go
+++ b/types/profile.go
@@ -12,3 +12,17 @@ type Profile struct {
 	Followers map[string]string
 	Following map[string]string
 }
+
+type Link struct {
+	Href string
+	Rel  string
+}
+
+type Alternative struct {
+	Type  string
+	Title string
+	URL   string
+}
+
+type Alternatives []Alternative
+type Links []Link

--- a/types/profile.go
+++ b/types/profile.go
@@ -1,4 +1,4 @@
-package internal
+package types
 
 type Profile struct {
 	Type string


### PR DESCRIPTION
##### Summary
Add `/api/v1/profile/:nick` endpoint which gets the profile of a feed/user

##### Component Name
area/backend

##### Test Plan
1. Hit `/api/v1/profile/:nick` with cURL or your browser
2. It returns this json 
<details>
 <summary>Result</summary>

```json
{
  "profile": {
    "Type": "User",
    "Username": "testing",
    "Tagline": "",
    "URL": "http://0.0.0.0:8000/user/testing/twtxt.txt",
    "TwtURL": "",
    "BlogsURL": "http://0.0.0.0:8000/blogs/testing",
    "Followers": {},
    "Following": {}
  },
  "links": [
    {
      "Href": "http://0.0.0.0:8000/user/testing/webmention",
      "Rel": "webmention"
    }
  ],
  "alternatives": [
    {
      "Type": "application/atom+xml",
      "Title": "twtxt.net local feed",
      "URL": "http://0.0.0.0:8000/atom.xml"
    },
    {
      "Type": "text/plain",
      "Title": "testing's Twtxt Feed",
      "URL": "http://0.0.0.0:8000/user/testing/twtxt.txt"
    },
    {
      "Type": "application/atom+xml",
      "Title": "testing's Atom Feed",
      "URL": "http://0.0.0.0:8000/user/testing/atom.xml"
    }
  ]
}
```
</details>
