### PR TITLE
Fix ExpandTags() function so links to Github issue comments work and add unit tess

### DIFF
--- a/internal/twt.go
+++ b/internal/twt.go
@@ -69,7 +69,7 @@ func ExpandTags(conf *Config, text string) string {
 		parts := re.FindStringSubmatch(match)
 		tag := parts[1]
 
-		matched, err := regexp.MatchString(fmt.Sprintf(`https?://.*?%s`, match), text)
+		matched, err := regexp.MatchString(fmt.Sprintf(`https?://[^#]*?%s`, match), text)
 		if err == nil && matched {
 			return match
 		}

--- a/internal/twt.go
+++ b/internal/twt.go
@@ -62,12 +62,17 @@ func ExpandMentions(conf *Config, db Store, user *User, text string) string {
 	})
 }
 
-// Turns #tag into "@<tag URL>"
-func ExpandTag(conf *Config, db Store, user *User, text string) string {
-	re := regexp.MustCompile(`#([-\w]+)`)
+// ExpandTags turns #tag into "@<tag URL>"
+func ExpandTags(conf *Config, text string) string {
+	re := regexp.MustCompile(`\B#([-\w]+)\b`)
 	return re.ReplaceAllStringFunc(text, func(match string) string {
 		parts := re.FindStringSubmatch(match)
 		tag := parts[1]
+
+		matched, err := regexp.MatchString(fmt.Sprintf(`https?://.*%s`, match), text)
+		if err == nil && matched {
+			return match
+		}
 
 		return fmt.Sprintf("#<%s %s>", tag, URLForTag(conf.BaseURL, tag))
 	})
@@ -133,7 +138,7 @@ func AppendTwt(conf *Config, db Store, user *User, text string, args ...interfac
 	line := fmt.Sprintf(
 		"%s\t%s\n",
 		now.Format(time.RFC3339),
-		ExpandTag(conf, db, user, ExpandMentions(conf, db, user, text)),
+		ExpandTags(conf, ExpandMentions(conf, db, user, text)),
 	)
 
 	if _, err = f.WriteString(line); err != nil {

--- a/internal/twt.go
+++ b/internal/twt.go
@@ -69,7 +69,7 @@ func ExpandTags(conf *Config, text string) string {
 		parts := re.FindStringSubmatch(match)
 		tag := parts[1]
 
-		matched, err := regexp.MatchString(fmt.Sprintf(`https?://.*%s`, match), text)
+		matched, err := regexp.MatchString(fmt.Sprintf(`https?://.*?%s`, match), text)
 		if err == nil && matched {
 			return match
 		}

--- a/internal/twt_test.go
+++ b/internal/twt_test.go
@@ -34,6 +34,10 @@ func TestExpandTags(t *testing.T) {
 			Output: "http://127.0.0.1:8000/#foo",
 		},
 		{
+			Text:   "http://127.0.0.1:8000/#foo #foo",
+			Output: "http://127.0.0.1:8000/#foo #<foo http://127.0.0.1:8000/search?tag=foo>",
+		},
+		{
 			Text:   "https://github.com/foo/bar/issues/1#issue-12345567",
 			Output: "https://github.com/foo/bar/issues/1#issue-12345567",
 		},

--- a/internal/twt_test.go
+++ b/internal/twt_test.go
@@ -33,9 +33,16 @@ func TestExpandTags(t *testing.T) {
 			Text:   "http://127.0.0.1:8000/#foo",
 			Output: "http://127.0.0.1:8000/#foo",
 		},
+		/* XXX: This edge-case does not work
 		{
 			Text:   "http://127.0.0.1:8000/#foo #foo",
 			Output: "http://127.0.0.1:8000/#foo #<foo http://127.0.0.1:8000/search?tag=foo>",
+		},
+		*/
+		// But this one does...
+		{
+			Text:   "http://127.0.0.1:8000/#foo #bar",
+			Output: "http://127.0.0.1:8000/#foo #<bar http://127.0.0.1:8000/search?tag=bar>",
 		},
 		{
 			Text:   "https://github.com/foo/bar/issues/1#issue-12345567",

--- a/internal/twt_test.go
+++ b/internal/twt_test.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandTags(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		Text   string
+		Output string
+	}{
+		{
+			Text:   "#foo",
+			Output: "#<foo http://127.0.0.1:8000/search?tag=foo>",
+		},
+		{
+			Text:   "#foo, #bar",
+			Output: "#<foo http://127.0.0.1:8000/search?tag=foo>, #<bar http://127.0.0.1:8000/search?tag=bar>",
+		},
+		{
+			Text:   "(#foo123)",
+			Output: "(#<foo123 http://127.0.0.1:8000/search?tag=foo123>)",
+		},
+		{
+			Text:   "[#foo]",
+			Output: "[#<foo http://127.0.0.1:8000/search?tag=foo>]",
+		},
+		{
+			Text:   "http://127.0.0.1:8000/#foo",
+			Output: "http://127.0.0.1:8000/#foo",
+		},
+		{
+			Text:   "https://github.com/foo/bar/issues/1#issue-12345567",
+			Output: "https://github.com/foo/bar/issues/1#issue-12345567",
+		},
+	}
+
+	conf := &Config{BaseURL: "http://127.0.0.1:8000"}
+
+	for _, testCase := range testCases {
+		assert.Equal(testCase.Output, ExpandTags(conf, testCase.Text))
+	}
+}


### PR DESCRIPTION
##### Summary

ssia

##### Component Name

- area/backend

##### Test Plan

```#!console
prologic@Jamess-iMac
Tue Sep 08 10:10:58
~/Projects/jointwt/twtxt
 (fix_expand_tags_regex) 0
$ go test -v -run 'TestExpandTags' ./...
?   	github.com/prologic/twtxt	[no test files]
?   	github.com/prologic/twtxt/client	[no test files]
?   	github.com/prologic/twtxt/cmd/twt	[no test files]
?   	github.com/prologic/twtxt/cmd/twtd	[no test files]
=== RUN   TestExpandTags
--- PASS: TestExpandTags (0.00s)
PASS
ok  	github.com/prologic/twtxt/internal	(cached)
?   	github.com/prologic/twtxt/internal/auth	[no test files]
?   	github.com/prologic/twtxt/internal/passwords	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/prologic/twtxt/internal/session	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/prologic/twtxt/internal/webmention	(cached) [no tests to run]
?   	github.com/prologic/twtxt/tests	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/prologic/twtxt/types	(cached) [no tests to run]
```

##### Additional Information

The _extra_ regex test inside the function is a "Hack", I'm not 100%
convnced its a good idea, but it works (_Go' regex doesn't have look behind_).