### PR TITLE
Remove unused CacheLastModified

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -84,18 +84,6 @@ func (cache *Cache) Store(path string) error {
 	return nil
 }
 
-// CacheLastModified ...
-func CacheLastModified(path string) (time.Time, error) {
-	stat, err := os.Stat(filepath.Join(path, feedCacheFile))
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return time.Time{}, err
-		}
-		return time.Unix(0, 0), nil
-	}
-	return stat.ModTime(), nil
-}
-
 // LoadCache ...
 func LoadCache(path string) (*Cache, error) {
 	cache := &Cache{

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -829,16 +829,7 @@ func (s *Server) PostHandler() httprouter.Handle {
 // TimelineHandler ...
 func (s *Server) TimelineHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		cacheLastModified, err := CacheLastModified(s.config.Data)
-		if err != nil {
-			log.WithError(err).Error("CacheLastModified() error")
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Last-Modified", cacheLastModified.UTC().Format(http.TimeFormat))
-
 		if r.Method == http.MethodHead {
 			defer r.Body.Close()
 			return
@@ -861,14 +852,6 @@ func (s *Server) TimelineHandler() httprouter.Handle {
 			}
 		}
 
-		if err != nil {
-			log.WithError(err).Error("error loading twts")
-			ctx.Error = true
-			ctx.Message = "An error occurred while loading the timeline"
-			s.render("error", w, ctx)
-			return
-		}
-
 		sort.Sort(twts)
 
 		var pagedTwts types.Twts
@@ -877,7 +860,7 @@ func (s *Server) TimelineHandler() httprouter.Handle {
 		pager := paginator.New(adapter.NewSliceAdapter(twts), s.config.TwtsPerPage)
 		pager.SetPage(page)
 
-		if err = pager.Results(&pagedTwts); err != nil {
+		if err := pager.Results(&pagedTwts); err != nil {
 			log.WithError(err).Error("error sorting and paging twts")
 			ctx.Error = true
 			ctx.Message = "An error occurred while loading the timeline"


### PR DESCRIPTION
##### Summary

Just some code cleanup.

Also remove the `Last-Modified_header` from the `TimelineHandler` on
`GET /` as we don't use this anyway and it provides no value currently.
See failed PR #199 :D

##### Component Name

- area/bakend

##### Test Plan

It builds

##### Additional Information