### PR TITLE
fix: Fix structtag for config

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -19,8 +19,8 @@ type Config struct {
 	Theme             string        `json:"theme"`
 	BaseURL           string        `json:"base_url"`
 	AdminUser         string        `json:"admin_user"`
-	AdminName         string        `json:"admin_user"`
-	AdminEmail        string        `json:"admin_user"`
+	AdminName         string        `json:"admin_name"`
+	AdminEmail        string        `json:"admin_email"`
 	FeedSources       []string      `json:"feed_sources"`
 	RegisterMessage   string        `json:"register_message"`
 	CookieSecret      string        `json:"cookie_secret"`


### PR DESCRIPTION
##### Summary
Noticed that the user_name struct tags are repeated
![image](https://user-images.githubusercontent.com/15314237/93291938-9b912f00-f7a1-11ea-9c76-4c8ba223ec47.png)

I wonder if we can turn on `govet`'s `structtag` check in golangci

##### Component Name
area/backend

##### Test Plan

##### Additional Information
