### PR TITLE
feat: Fetch the twts by external user slug

### DIFF
--- a/internal/api.go
+++ b/internal/api.go
@@ -77,7 +77,7 @@ func (a *API) initRoutes() {
 	router.POST("/discover", a.DiscoverEndpoint())
 
 	router.GET("/profile/:nick", a.ProfileEndpoint())
-	router.POST("/profile/:nick/twts", a.ProfileTwtsEndpoint())
+	router.POST("/fetch-twts", a.FetchTwtsEndpoint())
 
 	router.GET("/external/:slug/:nick", a.ExternalProfileEndpoint())
 
@@ -884,20 +884,20 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 }
 
 // ProfileTwtsEndpoint ...
-func (a *API) ProfileTwtsEndpoint() httprouter.Handle {
+func (a *API) FetchTwtsEndpoint() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-		req, err := types.NewPagedRequest(r.Body)
-		nick := NormalizeUsername(p.ByName("nick"))
+		req, err := types.NewFetchTwtsRequest(r.Body)
+		nick := NormalizeUsername(req.Nick)
 		if nick == "" {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}
 
-		nick = NormalizeUsername(nick)
-
 		var profile types.Profile
+		var twts types.Twts
 
 		if a.db.HasUser(nick) {
+			log.Debug("has user")
 			user, err := a.db.GetUser(nick)
 			if err != nil {
 				log.WithError(err).Errorf("error loading user object for %s", nick)
@@ -905,7 +905,9 @@ func (a *API) ProfileTwtsEndpoint() httprouter.Handle {
 				return
 			}
 			profile = user.Profile(a.config.BaseURL)
+			twts = a.cache.GetByURL(profile.URL)
 		} else if a.db.HasFeed(nick) {
+			log.Debug("has feed")
 			feed, err := a.db.GetFeed(nick)
 			if err != nil {
 				log.WithError(err).Errorf("error loading feed object for %s", nick)
@@ -913,12 +915,29 @@ func (a *API) ProfileTwtsEndpoint() httprouter.Handle {
 				return
 			}
 			profile = feed.Profile(a.config.BaseURL)
+
+			twts = a.cache.GetByURL(profile.URL)
+		} else if req.Slug != "" {
+			v, ok := slugs.Load(req.Slug)
+			if !ok {
+				http.Error(w, "User/Feed not found", http.StatusNotFound)
+				return
+			}
+
+			log.Debug("slug %s", v)
+			u := v.(*url.URL)
+			if !a.cache.IsCached(u.String()) {
+				log.Debug("is cached %s", u.String())
+				sources := make(types.Feeds)
+				sources[types.Feed{Nick: nick, URL: u.String()}] = true
+				a.cache.FetchTwts(a.config, a.archive, sources)
+			}
+
+			twts = a.cache.GetByURL(u.String())
 		} else {
 			http.Error(w, "User/Feed not found", http.StatusNotFound)
 			return
 		}
-
-		twts := a.cache.GetByURL(profile.URL)
 
 		sort.Sort(twts)
 

--- a/internal/api.go
+++ b/internal/api.go
@@ -897,7 +897,6 @@ func (a *API) FetchTwtsEndpoint() httprouter.Handle {
 		var twts types.Twts
 
 		if a.db.HasUser(nick) {
-			log.Debug("has user")
 			user, err := a.db.GetUser(nick)
 			if err != nil {
 				log.WithError(err).Errorf("error loading user object for %s", nick)
@@ -907,7 +906,6 @@ func (a *API) FetchTwtsEndpoint() httprouter.Handle {
 			profile = user.Profile(a.config.BaseURL)
 			twts = a.cache.GetByURL(profile.URL)
 		} else if a.db.HasFeed(nick) {
-			log.Debug("has feed")
 			feed, err := a.db.GetFeed(nick)
 			if err != nil {
 				log.WithError(err).Errorf("error loading feed object for %s", nick)
@@ -924,10 +922,8 @@ func (a *API) FetchTwtsEndpoint() httprouter.Handle {
 				return
 			}
 
-			log.Debug("slug %s", v)
 			u := v.(*url.URL)
 			if !a.cache.IsCached(u.String()) {
-				log.Debug("is cached %s", u.String())
 				sources := make(types.Feeds)
 				sources[types.Feed{Nick: nick, URL: u.String()}] = true
 				a.cache.FetchTwts(a.config, a.archive, sources)

--- a/types/api.go
+++ b/types/api.go
@@ -144,3 +144,20 @@ type ProfileResponse struct {
 	Alternatives Alternatives `json:"alternatives"`
 	Twter        Twter        `json:"twter"`
 }
+
+// FetchTwtsRequest ...
+type FetchTwtsRequest struct {
+	Slug string `json:"slug"`
+	Nick string `json:"nick"`
+	Page int    `json:"page"`
+}
+
+// NewFetchTwtsRequest ...
+func NewFetchTwtsRequest(r io.Reader) (req FetchTwtsRequest, err error) {
+	body, err := ioutil.ReadAll(r)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(body, &req)
+	return
+}


### PR DESCRIPTION
##### Summary
ssia. Did this by creating the fetch-twts endpoint that accepts a nick & slug. `slug` is only required for external users

##### Component Name
area/backend

##### Test Plan

<details>
<summary>Example request</summary>

Request

```HTTP
POST /api/v1/fetch-twts HTTP/1.1
Host: 0.0.0.0:8000
Content-Type: application/json
{
    "nick": "hjertnes",
    "slug": "hjertnes-social-twtxt-txt",
    "page": 0
}
```

Response

```JSON
{
    "twts": [
        {
            "twter": {
                "nick": "hjertnes",
                "url": "https://hjertnes.social/twtxt.txt",
                "avatar": "http://0.0.0.0:8000/external/hjertnes-social-twtxt-txt/hjertnes/avatar",
                "tagline": "",
                "slug": "hjertnes-social-twtxt-txt"
            },
            "text": "tmux inception",
            "created": "2020-09-18T06:03:18+02:00",
            "hash": "ymsgkna"
        },
        {
            "twter": {
                "nick": "hjertnes",
                "url": "https://hjertnes.social/twtxt.txt",
                "avatar": "http://0.0.0.0:8000/external/hjertnes-social-twtxt-txt/hjertnes/avatar",
                "tagline": "",
                "slug": "hjertnes-social-twtxt-txt"
            },
            "text": "Are there some Apple event today?",
            "created": "2020-09-15T19:34:28+02:00",
            "hash": "l7kriya"
        }
    ],
    "Pager": {
        "current_page": 1,
        "max_pages": 1,
        "total_twts": 2
    }
}
```

</details>
