### PR TITLE
Refactor use of slugs

### DIFF
--- a/internal/api.go
+++ b/internal/api.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -79,7 +78,7 @@ func (a *API) initRoutes() {
 	router.GET("/profile/:nick", a.ProfileEndpoint())
 	router.POST("/fetch-twts", a.FetchTwtsEndpoint())
 
-	router.GET("/external/:slug/:nick", a.ExternalProfileEndpoint())
+	router.GET("/external/:url/:nick", a.ExternalProfileEndpoint())
 
 	router.POST("/mentions", a.isAuthorized(a.MentionsEndpoint()))
 }
@@ -915,21 +914,14 @@ func (a *API) FetchTwtsEndpoint() httprouter.Handle {
 			profile = feed.Profile(a.config.BaseURL)
 
 			twts = a.cache.GetByURL(profile.URL)
-		} else if req.Slug != "" {
-			v, ok := slugs.Load(req.Slug)
-			if !ok {
-				http.Error(w, "User/Feed not found", http.StatusNotFound)
-				return
-			}
-
-			u := v.(*url.URL)
-			if !a.cache.IsCached(u.String()) {
+		} else if req.URL != "" {
+			if !a.cache.IsCached(req.URL) {
 				sources := make(types.Feeds)
-				sources[types.Feed{Nick: nick, URL: u.String()}] = true
+				sources[types.Feed{Nick: nick, URL: req.URL}] = true
 				a.cache.FetchTwts(a.config, a.archive, sources)
 			}
 
-			twts = a.cache.GetByURL(u.String())
+			twts = a.cache.GetByURL(req.URL)
 		} else {
 			http.Error(w, "User/Feed not found", http.StatusNotFound)
 			return
@@ -971,28 +963,18 @@ func (a *API) FetchTwtsEndpoint() httprouter.Handle {
 // ExternalProfileEndpoint ...
 func (a *API) ExternalProfileEndpoint() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-		slug := p.ByName("slug")
+		url := p.ByName("url")
 		nick := p.ByName("nick")
 
-		if slug == "" {
+		if url == "" {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}
-
-		v, ok := slugs.Load(slug)
-		if !ok {
-			http.Error(w, "Bad Request", http.StatusBadRequest)
-			return
-		}
-
-		u := v.(*url.URL)
 
 		if nick == "" {
 			log.Warn("no nick given to external profile request")
 			nick = "unknown"
 		}
-
-		url := u.String()
 
 		profileResponse := types.ProfileResponse{}
 

--- a/internal/api.go
+++ b/internal/api.go
@@ -886,6 +886,12 @@ func (a *API) ProfileEndpoint() httprouter.Handle {
 func (a *API) FetchTwtsEndpoint() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		req, err := types.NewFetchTwtsRequest(r.Body)
+		if err != nil {
+			log.WithError(err).Error("error parsing fetch twts request")
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
 		nick := NormalizeUsername(req.Nick)
 		if nick == "" {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
@@ -963,8 +969,15 @@ func (a *API) FetchTwtsEndpoint() httprouter.Handle {
 // ExternalProfileEndpoint ...
 func (a *API) ExternalProfileEndpoint() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-		url := p.ByName("url")
-		nick := p.ByName("nick")
+		req, err := types.NewExternalProfileRequest(r.Body)
+		if err != nil {
+			log.WithError(err).Error("error parsing external profile request")
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		url := req.URL
+		nick := req.Nick
 
 		if url == "" {
 			http.Error(w, "Bad Request", http.StatusBadRequest)

--- a/internal/api.go
+++ b/internal/api.go
@@ -986,7 +986,7 @@ func (a *API) ExternalProfileEndpoint() httprouter.Handle {
 
 		profileResponse.Twter = types.Twter{
 			Nick:   nick,
-			Avatar: URLForExternalAvatar(a.config, nick, url),
+			Avatar: URLForExternalAvatar(a.config, url),
 			URL:    URLForExternalProfile(a.config, nick, url),
 		}
 

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -205,7 +205,7 @@ func (cache *Cache) FetchTwts(conf *Config, archive Archiver, feeds types.Feeds)
 					twter.URL = feed.URL
 					avatar := GetExternalAvatar(conf, feed.Nick, feed.URL)
 					if avatar != "" {
-						twter.Avatar = URLForExternalAvatar(conf, feed.Nick, feed.URL)
+						twter.Avatar = URLForExternalAvatar(conf, feed.URL)
 					}
 				}
 				twts, old, err := ParseFile(scanner, twter, conf.MaxCacheTTL, conf.MaxCacheItems)

--- a/internal/server.go
+++ b/internal/server.go
@@ -503,9 +503,9 @@ func (s *Server) initRoutes() {
 	s.router.POST("/user/:nick/webmention", s.WebMentionHandler())
 
 	// External Feeds
-	s.router.GET("/external/:url/:nick", s.ExternalHandler())
-	s.router.GET("/external/:url/:nick/avatar", s.ExternalAvatarHandler())
-	s.router.HEAD("/external/:url/:nick/avatar", s.ExternalAvatarHandler())
+	s.router.GET("/external", s.ExternalHandler())
+	s.router.GET("/externalAvatar", s.ExternalAvatarHandler())
+	s.router.HEAD("/externalAvatar", s.ExternalAvatarHandler())
 
 	// Syndication Formats (RSS, Atom, JSON Feed)
 	s.router.HEAD("/atom.xml", s.SyndicationHandler())

--- a/internal/server.go
+++ b/internal/server.go
@@ -503,9 +503,9 @@ func (s *Server) initRoutes() {
 	s.router.POST("/user/:nick/webmention", s.WebMentionHandler())
 
 	// External Feeds
-	s.router.GET("/external/:slug/:nick", s.ExternalHandler())
-	s.router.GET("/external/:slug/:nick/avatar", s.ExternalAvatarHandler())
-	s.router.HEAD("/external/:slug/:nick/avatar", s.ExternalAvatarHandler())
+	s.router.GET("/external/:url/:nick", s.ExternalHandler())
+	s.router.GET("/external/:url/:nick/avatar", s.ExternalAvatarHandler())
+	s.router.HEAD("/external/:url/:nick/avatar", s.ExternalAvatarHandler())
 
 	// Syndication Formats (RSS, Atom, JSON Feed)
 	s.router.HEAD("/atom.xml", s.SyndicationHandler())

--- a/internal/templates.go
+++ b/internal/templates.go
@@ -34,7 +34,6 @@ func NewTemplates(conf *Config, blogs *BlogsCache, cache *Cache) (*Templates, er
 	funcMap := sprig.FuncMap()
 
 	funcMap["time"] = humanize.Time
-	funcMap["slugify"] = Slugify
 	funcMap["prettyURL"] = PrettyURL
 	funcMap["isLocalURL"] = IsLocalURLFactory(conf)
 	funcMap["formatTwt"] = FormatTwtFactory(conf)

--- a/internal/templates/_partials.html
+++ b/internal/templates/_partials.html
@@ -92,7 +92,7 @@
             <a href="{{ $.Twt.Twter.URL | trimSuffix "/twtxt.txt" }}" class="u-url">
               <img class="avatar u-photo" src="/user/{{ $.Twt.Twter.Nick }}/avatar" />
           {{ else }}
-            <a href="/external/{{ $.Twt.Twter.URL | slugify }}/{{ $.Twt.Twter.Nick  }}" class="u-url">
+            <a href="/external/{{ $.Twt.Twter.URL }}/{{ $.Twt.Twter.Nick  }}" class="u-url">
               {{ if $.Twt.Twter.Avatar }}
                 <img class="avatar u-photo" src="{{ $.Twt.Twter.Avatar }}" />
               {{ else }}

--- a/internal/templates/_partials.html
+++ b/internal/templates/_partials.html
@@ -92,7 +92,7 @@
             <a href="{{ $.Twt.Twter.URL | trimSuffix "/twtxt.txt" }}" class="u-url">
               <img class="avatar u-photo" src="/user/{{ $.Twt.Twter.Nick }}/avatar" />
           {{ else }}
-            <a href="/external/{{ $.Twt.Twter.URL }}/{{ $.Twt.Twter.Nick  }}" class="u-url">
+            <a href="/external?uri={{ $.Twt.Twter.URL }}&nick={{ $.Twt.Twter.Nick  }}" class="u-url">
               {{ if $.Twt.Twter.Avatar }}
                 <img class="avatar u-photo" src="{{ $.Twt.Twter.Avatar }}" />
               {{ else }}

--- a/internal/templates/feeds.html
+++ b/internal/templates/feeds.html
@@ -108,7 +108,7 @@
           <ul>
             {{ range $Feeds }}
               <li>
-                <a href="/external/{{ .URL | slugify }}/{{ .Name  }}">{{ .Name }}</a>
+                <a href="/external/{{ .URL }}/{{ .Name  }}">{{ .Name }}</a>
                 &nbsp;
                 {{ if $.User.Follows .URL }}
                   [<a href="/unfollow?nick={{ .Name  }}">Unfollow</a>]

--- a/internal/templates/feeds.html
+++ b/internal/templates/feeds.html
@@ -108,7 +108,7 @@
           <ul>
             {{ range $Feeds }}
               <li>
-                <a href="/external/{{ .URL }}/{{ .Name  }}">{{ .Name }}</a>
+                <a href="/external?uri={{ .URL }}&nick={{ .Name  }}">{{ .Name }}</a>
                 &nbsp;
                 {{ if $.User.Follows .URL }}
                   [<a href="/unfollow?nick={{ .Name  }}">Unfollow</a>]

--- a/internal/templates/followers.html
+++ b/internal/templates/followers.html
@@ -21,7 +21,7 @@
                 {{ if isLocalURL $URL }}
                   <a href="{{ $URL | trimSuffix "/twtxt.txt" }}">{{ $Nick }}</a>
                 {{ else }}
-                  <a href="/external/{{ $URL | slugify }}/{{ $Nick  }}">
+                  <a href="/external/{{ $URL }}/{{ $Nick  }}">
                 {{ end }}
                 (<a href="{{ $URL }}">{{ $URL }}</a>)
 

--- a/internal/templates/followers.html
+++ b/internal/templates/followers.html
@@ -21,7 +21,7 @@
                 {{ if isLocalURL $URL }}
                   <a href="{{ $URL | trimSuffix "/twtxt.txt" }}">{{ $Nick }}</a>
                 {{ else }}
-                  <a href="/external/{{ $URL }}/{{ $Nick  }}">
+                  <a href="/external?uri={{ $URL }}&nick={{ $Nick  }}">
                 {{ end }}
                 (<a href="{{ $URL }}">{{ $URL }}</a>)
 

--- a/internal/templates/following.html
+++ b/internal/templates/following.html
@@ -18,7 +18,7 @@
               {{ if isLocalURL $URL }}
                 <a href="{{ $URL | trimSuffix "/twtxt.txt" }}">
               {{ else }}
-                <a href="/external/{{ $URL }}/{{ $Nick  }}">
+                <a href="/external?uri={{ $URL }}&nick={{ $Nick  }}">
               {{ end }}
               {{ if $.User.Is $URL }}me{{ else }}{{ $Nick }}{{ end }}
 

--- a/internal/templates/following.html
+++ b/internal/templates/following.html
@@ -18,7 +18,7 @@
               {{ if isLocalURL $URL }}
                 <a href="{{ $URL | trimSuffix "/twtxt.txt" }}">
               {{ else }}
-                <a href="/external/{{ $URL | slugify }}/{{ $Nick  }}">
+                <a href="/external/{{ $URL }}/{{ $Nick  }}">
               {{ end }}
               {{ if $.User.Is $URL }}me{{ else }}{{ $Nick }}{{ end }}
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -80,8 +80,6 @@ const (
 )
 
 var (
-	slugs *sync.Map
-
 	specialUsernames = []string{
 		newsSpecialUser,
 		helpSpecialUser,
@@ -120,10 +118,6 @@ var (
 	}
 )
 
-func init() {
-	slugs = &sync.Map{}
-}
-
 func Slugify(uri string) string {
 	u, err := url.Parse(uri)
 	if err != nil {
@@ -131,10 +125,7 @@ func Slugify(uri string) string {
 		return ""
 	}
 
-	s := slug.Make(fmt.Sprintf("%s/%s", u.Hostname(), u.Path))
-	slugs.Store(s, u)
-
-	return s
+	return slug.Make(fmt.Sprintf("%s/%s", u.Hostname(), u.Path))
 }
 
 func GenerateAvatar(conf *Config, username string) (image.Image, error) {
@@ -192,9 +183,9 @@ func ImageToPng(fn string) error {
 }
 
 func GetExternalAvatar(conf *Config, nick, uri string) string {
-	name := Slugify(uri)
+	slug := Slugify(uri)
 
-	fn := filepath.Join(conf.Data, externalDir, fmt.Sprintf("%s.webp", name))
+	fn := filepath.Join(conf.Data, externalDir, fmt.Sprintf("%s.webp", slug))
 	if FileExists(fn) {
 		return URLForExternalAvatar(conf, nick, uri)
 	}
@@ -223,7 +214,7 @@ func GetExternalAvatar(conf *Config, nick, uri string) string {
 		source, _ := base.Parse(candidate)
 		if ResourceExists(conf, source.String()) {
 			opts := &ImageOptions{Resize: true, ResizeW: AvatarResolution, ResizeH: AvatarResolution}
-			_, err := DownloadImage(conf, source.String(), externalDir, name, opts)
+			_, err := DownloadImage(conf, source.String(), externalDir, slug, opts)
 			if err != nil {
 				log.WithError(err).
 					WithField("base", base.String()).
@@ -1028,7 +1019,7 @@ func URLForExternalProfile(conf *Config, nick, url string) string {
 	return fmt.Sprintf(
 		"%s/external/%s/%s",
 		strings.TrimSuffix(conf.BaseURL, "/"),
-		Slugify(url), nick,
+		url, nick,
 	)
 }
 
@@ -1036,7 +1027,7 @@ func URLForExternalAvatar(conf *Config, nick, url string) string {
 	return fmt.Sprintf(
 		"%s/external/%s/%s/avatar",
 		strings.TrimSuffix(conf.BaseURL, "/"),
-		Slugify(url), nick,
+		url, nick,
 	)
 }
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -187,7 +187,7 @@ func GetExternalAvatar(conf *Config, nick, uri string) string {
 
 	fn := filepath.Join(conf.Data, externalDir, fmt.Sprintf("%s.webp", slug))
 	if FileExists(fn) {
-		return URLForExternalAvatar(conf, nick, uri)
+		return URLForExternalAvatar(conf, uri)
 	}
 
 	if !strings.HasSuffix(uri, "/") {
@@ -222,7 +222,7 @@ func GetExternalAvatar(conf *Config, nick, uri string) string {
 					Error("error downloading external avatar")
 				return ""
 			}
-			return URLForExternalAvatar(conf, nick, uri)
+			return URLForExternalAvatar(conf, uri)
 		}
 	}
 
@@ -1015,19 +1015,19 @@ func URLForAvatar(conf *Config, username string) string {
 	)
 }
 
-func URLForExternalProfile(conf *Config, nick, url string) string {
+func URLForExternalProfile(conf *Config, nick, uri string) string {
 	return fmt.Sprintf(
-		"%s/external/%s/%s",
+		"%s/external?uri=%s&nick%s",
 		strings.TrimSuffix(conf.BaseURL, "/"),
-		url, nick,
+		uri, nick,
 	)
 }
 
-func URLForExternalAvatar(conf *Config, nick, url string) string {
+func URLForExternalAvatar(conf *Config, uri string) string {
 	return fmt.Sprintf(
-		"%s/external/%s/%s/avatar",
+		"%s/externalAvatar?uri=%s",
 		strings.TrimSuffix(conf.BaseURL, "/"),
-		url, nick,
+		uri,
 	)
 }
 

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -28,12 +28,12 @@ func TestFormatMentionsAndTags(t *testing.T) {
 		{
 			text:     "@<iamexternal http://iamexternal.com/twtxt.txt>",
 			format:   HTMLFmt,
-			expected: fmt.Sprintf(`<a href="%s">@iamexternal</a>`, URLForExternalProfile(conf, "iamexternal", "http://iamexternal.com/twtxt.txt>")),
+			expected: fmt.Sprintf(`<a href="%s">@iamexternal</a>`, URLForExternalProfile(conf, "iamexternal", "http://iamexternal.com/twtxt.txt")),
 		},
 		{
 			text:     "@<iamexternal http://iamexternal.com/twtxt.txt>",
 			format:   MarkdownFmt,
-			expected: fmt.Sprintf(`[@iamexternal](%s)`, URLForExternalProfile(conf, "iamexternal", "http://iamexternal.com/twtxt.txt>")),
+			expected: fmt.Sprintf(`[@iamexternal](%s)`, URLForExternalProfile(conf, "iamexternal", "http://iamexternal.com/twtxt.txt")),
 		},
 		{
 			text:     "#<test http://0.0.0.0:8000/search?tag=test>",

--- a/internal/webmention/webmention.go
+++ b/internal/webmention/webmention.go
@@ -177,7 +177,7 @@ func searchLinks(node *html.Node, link *url.URL) bool {
 				target, err := url.Parse(href)
 				if err == nil {
 					// prologic/twtxt pods have the form
-					// http://pod.domain.tld/external/uri/nick
+					// http://pod.domain.tld/external?uri=uri&nick=nick
 					if strings.HasPrefix(target.Path, "/external") && target.Query().Get("url") == link.String() {
 						return true
 					}

--- a/types/api.go
+++ b/types/api.go
@@ -161,3 +161,19 @@ func NewFetchTwtsRequest(r io.Reader) (req FetchTwtsRequest, err error) {
 	err = json.Unmarshal(body, &req)
 	return
 }
+
+// ExternalProfileRequest ...
+type ExternalProfileRequest struct {
+	URL  string `json:"url"`
+	Nick string `json:"nick"`
+}
+
+// NewExternalProfileRequest ...
+func NewExternalProfileRequest(r io.Reader) (req ExternalProfileRequest, err error) {
+	body, err := ioutil.ReadAll(r)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(body, &req)
+	return
+}

--- a/types/api.go
+++ b/types/api.go
@@ -147,7 +147,7 @@ type ProfileResponse struct {
 
 // FetchTwtsRequest ...
 type FetchTwtsRequest struct {
-	Slug string `json:"slug"`
+	URL  string `json:"url"`
 	Nick string `json:"nick"`
 	Page int    `json:"page"`
 }

--- a/types/twt.go
+++ b/types/twt.go
@@ -4,13 +4,10 @@ import (
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"regexp"
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-	"github.com/writeas/slug"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -30,33 +27,17 @@ func (twter Twter) IsZero() bool {
 	return twter.Nick == "" && twter.URL == ""
 }
 
-func (twter Twter) Slug() string {
-	u, err := url.Parse(twter.URL)
-	if err != nil {
-		log.WithError(err).Warnf("Twter.Slug(): error parsing url: %s", twter.URL)
-		return ""
-	}
-
-	return slug.Make(fmt.Sprintf("%s/%s", u.Hostname(), u.Path))
-}
-
 func (twter Twter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Nick    string `json:"nick"`
 		URL     string `json:"url"`
 		Avatar  string `json:"avatar"`
 		Tagline string `json:"tagline"`
-
-		// Dynamic Fields
-		Slug string `json:"slug"`
 	}{
 		Nick:    twter.Nick,
 		URL:     twter.URL,
 		Avatar:  twter.Avatar,
 		Tagline: twter.Tagline,
-
-		// Dynamic Fields
-		Slug: twter.Slug(),
 	})
 }
 


### PR DESCRIPTION
##### Summary

ssia - Makes use of slugs a bit simpler to understand. They are only
used when we have to construct filenames on a filesystem. Otherwise we
mostly use URI(s) like we should have done the whole time.

##### Component Name

- area/backend

##### Test Plan

@prologic and @dooven to test locally

##### Additional Information