### PR TITLE
Change the format of markdown links for twt user

### DIFF
--- a/internal/api.go
+++ b/internal/api.go
@@ -994,7 +994,7 @@ func (a *API) ExternalProfileEndpoint() httprouter.Handle {
 		profileResponse.Profile = types.Profile{
 			Username: nick,
 			TwtURL:   url,
-			URL:      URLForExternalProfile(a.config, nick, url),
+			URL:      url,
 		}
 
 		profileResponse.Twter = types.Twter{

--- a/internal/api.go
+++ b/internal/api.go
@@ -78,7 +78,7 @@ func (a *API) initRoutes() {
 	router.GET("/profile/:nick", a.ProfileEndpoint())
 	router.POST("/fetch-twts", a.FetchTwtsEndpoint())
 
-	router.GET("/external/:url/:nick", a.ExternalProfileEndpoint())
+	router.POST("/external", a.ExternalProfileEndpoint())
 
 	router.POST("/mentions", a.isAuthorized(a.MentionsEndpoint()))
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1411,9 +1411,9 @@ func FormatMentionsAndTags(conf *Config, text string, format TwtTextFormat) stri
 		switch prefix {
 		case "@":
 			if isLocalURL(url) && strings.HasSuffix(url, "/twtxt.txt") {
-				return fmt.Sprintf(`[@%s](%s)`, nick, UserURL(url))
+				return fmt.Sprintf(`[@%s](%s|%s)`, nick, nick, url)
 			}
-			return fmt.Sprintf(`[@%s](%s)`, nick, URLForExternalProfile(conf, nick, url))
+			return fmt.Sprintf(`[@%s](%s|%s)`, nick, nick, url)
 		default:
 			return fmt.Sprintf(`[%s%s](%s)`, prefix, nick, url)
 		}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1411,6 +1411,9 @@ func FormatMentionsAndTags(conf *Config, text string, format TwtTextFormat) stri
 		switch prefix {
 		case "@":
 			if isLocalURL(url) && strings.HasSuffix(url, "/twtxt.txt") {
+				// Using (#) anchors to add the nick to URL for now. The Fluter app needs it since
+				// 	the Markdown plugin doesn't include the link text that contains the nick in its onTap callback
+				// https://github.com/flutter/flutter_markdown/issues/286
 				return fmt.Sprintf(`[@%s](%s#%s)`, nick, url, nick)
 			}
 			return fmt.Sprintf(`[@%s](%s#%s)`, nick, url, nick)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1411,9 +1411,9 @@ func FormatMentionsAndTags(conf *Config, text string, format TwtTextFormat) stri
 		switch prefix {
 		case "@":
 			if isLocalURL(url) && strings.HasSuffix(url, "/twtxt.txt") {
-				return fmt.Sprintf(`[@%s](%s|%s)`, nick, nick, url)
+				return fmt.Sprintf(`[@%s](%s#%s)`, nick, url, nick)
 			}
-			return fmt.Sprintf(`[@%s](%s|%s)`, nick, nick, url)
+			return fmt.Sprintf(`[@%s](%s#%s)`, nick, url, nick)
 		default:
 			return fmt.Sprintf(`[%s%s](%s)`, prefix, nick, url)
 		}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -23,7 +23,7 @@ func TestFormatMentionsAndTags(t *testing.T) {
 		{
 			text:     "@<test http://0.0.0.0:8000/user/test/twtxt.txt>",
 			format:   MarkdownFmt,
-			expected: `[@test](http://0.0.0.0:8000/user/test)`,
+			expected: "[@test](test|http://0.0.0.0:8000/user/test/twtxt.txt)",
 		},
 		{
 			text:     "@<iamexternal http://iamexternal.com/twtxt.txt>",

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -23,7 +23,7 @@ func TestFormatMentionsAndTags(t *testing.T) {
 		{
 			text:     "@<test http://0.0.0.0:8000/user/test/twtxt.txt>",
 			format:   MarkdownFmt,
-			expected: "[@test](test|http://0.0.0.0:8000/user/test/twtxt.txt)",
+			expected: "[@test](http://0.0.0.0:8000/user/test/twtxt.txt#test)",
 		},
 		{
 			text:     "@<iamexternal http://iamexternal.com/twtxt.txt>",
@@ -33,7 +33,7 @@ func TestFormatMentionsAndTags(t *testing.T) {
 		{
 			text:     "@<iamexternal http://iamexternal.com/twtxt.txt>",
 			format:   MarkdownFmt,
-			expected: fmt.Sprintf(`[@iamexternal](%s)`, URLForExternalProfile(conf, "iamexternal", "http://iamexternal.com/twtxt.txt")),
+			expected: "[@iamexternal](http://iamexternal.com/twtxt.txt#iamexternal)",
 		},
 		{
 			text:     "#<test http://0.0.0.0:8000/search?tag=test>",


### PR DESCRIPTION
##### Summary
We want it so that we can get the nick + url from the Twt.Text. We also want it so that  it's easier to parse. 

I changed the Twt.Text format for the markdown to 
```
[@<user/feed_name>](<user/feed_name>|http://0.0.0.0:8000/user/<user>/twtxt.txt)
```

e.g.

```
[@test](test|http://0.0.0.0:8000/user/test/twtxt.txt)
```
##### Component Name
area/backend
##### Test Plan
Test it locally with the app
##### Additional Information
