### PR TITLE
Add OpenGraph Meta tags to Twt Permalinks

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -17,9 +17,11 @@ import (
 
 type Meta struct {
 	Title       string
-	Author      string
-	Keywords    string
 	Description string
+	Image       string
+	Author      string
+	URL         string
+	Keywords    string
 }
 
 type Context struct {
@@ -32,7 +34,7 @@ type Context struct {
 	TwtPrompt               string
 	MaxTwtLength            int
 	RegisterDisabled        bool
-	OpenProfiles			bool
+	OpenProfiles            bool
 	RegisterDisabledMessage string
 
 	Timezones []*timezones.Zoneinfo
@@ -44,7 +46,7 @@ type Context struct {
 	LastTwt       types.Twt
 	Profile       types.Profile
 	Authenticated bool
-	IsAdmin 	  bool
+	IsAdmin       bool
 
 	Error   bool
 	Message string
@@ -80,7 +82,7 @@ func NewContext(conf *Config, db Store, req *http.Request) *Context {
 		TwtPrompt:        conf.RandomTwtPrompt(),
 		MaxTwtLength:     conf.MaxTwtLength,
 		RegisterDisabled: !conf.OpenRegistrations,
-		OpenProfiles:	  conf.OpenProfiles,
+		OpenProfiles:     conf.OpenProfiles,
 
 		Commit: twtxt.Commit,
 		Theme:  conf.Theme,

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -893,6 +893,8 @@ func (s *Server) WebMentionHandler() httprouter.Handle {
 
 // PermalinkHandler ...
 func (s *Server) PermalinkHandler() httprouter.Handle {
+	formatTwt := FormatTwtFactory(s.config)
+
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		ctx := NewContext(s.config, s.db, r)
 
@@ -956,10 +958,15 @@ func (s *Server) PermalinkHandler() httprouter.Handle {
 			return
 		}
 
-		ctx.Title = fmt.Sprintf("%s @ %s > %s ", who, when, what)
+		title := fmt.Sprintf("%s at %s said", who, when)
+
+		ctx.Title = title
 		ctx.Meta = Meta{
+			Title:       title,
+			Description: string(formatTwt(what)),
 			Author:      who,
-			Description: what,
+			Image:       URLForAvatar(s.config, who),
+			URL:         r.URL.String(),
 			Keywords:    strings.Join(ks, ", "),
 		}
 		if strings.HasPrefix(twt.Twter.URL, s.config.BaseURL) {

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -21,6 +21,13 @@
     {{ with .Meta.Author }}<meta name="author" content="{{ . }}">{{ end }}
     {{ with .Meta.Keywords }}<meta name="keywords" content="{{ . }}">{{ end }}
     {{ with .Meta.Description }}<meta name="description" content="{{ . }}">{{ end }}
+
+    <!-- OpenGraph Meta Tags -->
+    {{ with .Meta.Title}}<meta property="og:title" content="{{ . }}">{{ end  }}
+    {{ with .Meta.Description}}<meta property="og:description" content="{{ . }}">{{ end  }}
+    {{ with .Meta.Image}}<meta property="og:image" content="{{ . }}">{{ end  }}
+    {{ with .Meta.URL}}<meta property="og:url" content="{{ . }}">{{ end  }}
+    <meta property="og:site_name" content="{{ .InstanceName }}">
   </head>
 <body>
   <nav id="mainNav" class="container-fluid">


### PR DESCRIPTION
##### Summary

ssia

##### Component Name

- area/backend

##### Test Plan

Review, Test in Prod with validators.

<img width="1001" alt="Screen Shot 2020-10-05 at 13 05 55" src="https://user-images.githubusercontent.com/1290234/95036581-ba814200-070b-11eb-9e3f-ca92192af8dc.png">

<img width="1312" alt="Screen Shot 2020-10-05 at 13 06 02" src="https://user-images.githubusercontent.com/1290234/95036595-bf45f600-070b-11eb-840f-f6ec7e604065.png">

##### Additional Information