### PR TITLE
WIP: Improve the Docker image security by ensuring that `twtd` runs as `uid!=0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,13 +55,19 @@ FROM alpine:latest
 
 RUN apk --no-cache -U add ca-certificates tzdata ffmpeg
 
-WORKDIR /
+RUN adduser -D -H twtd twtd
+RUN mkdir -p /data && chown -R twtd:twtd /data
+
 VOLUME /data
+
+WORKDIR /
 
 # force cgo resolver
 ENV GODEBUG=netdns=cgo
 
 COPY --from=build /src/twtd /twtd
+
+USER twtd
 
 ENTRYPOINT ["/twtd"]
 CMD [""]

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ also have that configured and running in your cluster appropriately.
 docker stack deploy -c twtxt.yml
 ```
 
+__NOTE:__ The [Dockerfile](/Dockerfile) specifies that the container run as
+          the user `twtd` with `uid=1000`. Be sure that any volume(s) you
+          mount into your container and use as the data storage (`-d/--data`)
+          path and database storage path (`-s/--store`) is correctly configured
+          to have the correct user/group ownership. e.g: `chorn -R 1000:1000 /data`
+
 ## Sponsor
 
 Support the ongoing development of twtxt!


### PR DESCRIPTION
##### Summary

ssia

##### Component Name

- area/packaging

##### Test Plan

Tested locally:

- Build an old image
- Ran it with a named volume
- Ran the new image, it failed with permission errors.
- Fixed the named volume's user/group ownerships.
- Ran the new image, it woris.

##### Additional Information

**NOTE:** This is going to require some _small_ amount of downtime when this gets rolled out as it will break all existing [Twt.social](https://twt.social) pods we manage as well as [Twtxt.net](https://twtxt.net) itself. I will have to go and fix the ownership of all data stored in volumes for all pods we manage.