### PR TITLE
Use RFC 3339 formatted timestamp in twt hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@
 /data/external/*
 
 /internal/rice-box.go
+
+/docs/_site/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 *.idea
 .vscode
+*.sw?
 
 /dist
 

--- a/docs/_posts/2020-12-11-twthashextension.md
+++ b/docs/_posts/2020-12-11-twthashextension.md
@@ -1,0 +1,104 @@
+---
+layout: page
+title: "Twt Hash Extension"
+category: doc
+date: 2020-12-11 15:00:00
+order: 3
+---
+
+At [twtxt.net](https://twtxt.net/) the **Twt Hash** was invented as an
+extension to the original [Twtxt File Format
+Specification](https://twtxt.readthedocs.io/en/latest/user/twtxtfile.html#format-specification).
+
+## Purpose
+
+Twt hashes make twts identifiable, so replies can be created to build up
+conversations. The twt's hash is used in the **Twt Subject** (another
+extension) of the reply twt to indicate to which original twt it refers to. The
+twt hash is similar to the `Message-ID` header of an e-mail which the response
+e-mail would reference in its `In-Reply-To` header.
+
+Another use case of twt hashes in some twtxt clients is to store which twts
+have already been read by the user. Then they can be hidden the next time the
+timeline is presented to the user.
+
+## Format
+
+Each twt's hash is calculated using its author, timestamp and contents. The
+author feed URL, RFC 3339 formatted timestamp and twt text are joined with line
+feeds:
+
+```
+<twt author feed URL> "\n"
+<twt timestamp in RFC 3339> "\n"
+<twt text>
+```
+
+This UTF-8 encoded string is Blake2b hashed with 256 bits and Base32 encoded
+without padding. After converting to lower case the last seven characters make
+up the twt hash.
+
+### Timestamp Format
+
+The twt timestamp must be [RFC 3339](https://tools.ietf.org/html/rfc3339)-formatted,
+e.g.:
+
+```
+2020-12-13T08:45:23+01:00
+2020-12-13T07:45:23Z
+```
+
+The time must exactly be truncated or expanded to seconds precision. Any
+possible milliseconds must be cut off without any rounding. The seconds part of
+minutes precision times must be set to zero.
+
+```
+2020-12-13T08:45:23.789+01:00 → 2020-12-13T08:45:23+01:00
+2020-12-13T08:45+01:00        → 2020-12-13T08:45:00+01:00
+```
+
+All timezones representing UTC must be formatted using the designated Zulu
+indicator `Z` rather than the numeric offsets `+00:00` or `-00:00`. If the
+timestamp does not explicitly include any timezone information, it must be
+assumed to be in UTC.
+
+```
+2020-12-13T07:45:23+00:00 → 2020-12-13T07:45:23Z
+2020-12-13T07:45:23-00:00 → 2020-12-13T07:45:23Z
+2020-12-13T07:45:23       → 2020-12-13T07:45:23Z
+```
+
+Other timezone conversations must not be applied. Even though two timestamps
+represent the exact point in time in two different time zones, the twt's
+original timezone must be used. The following example is illegal:
+
+```
+2020-12-13T08:45:23+01:00 → 2020-12-13T07:45:23Z (illegal)
+```
+
+As the exact timestamp format will affect the twt hash, these rules must be
+followed without any exception.
+
+## Reference Implementation
+
+This section shows reference implementations of this algorithm.
+
+### Go
+
+```
+payload := twt.Twter.URL + "\n" + twt.Created.Format(time.RFC3339) + "\n" + twt.Text
+sum := blake2b.Sum256([]byte(payload))
+encoding := base32.StdEncoding.WithPadding(base32.NoPadding)
+hash := strings.ToLower(encoding.EncodeToString(sum[:]))
+hash = hash[len(hash)-7:]
+```
+
+### Python 3
+
+```
+created = twt.created.isoformat().replace("+00:00", "Z")
+payload = "%s\n%s\n%s" % (twt.twter.url, created, twt.text)
+sum256 = hashlib.blake2b(payload.encode("utf-8"), digest_size=32).digest()
+hash = base64.b32encode(sum256).decode("ascii").replace("=", "").lower()[-7:]
+```
+

--- a/types/twt.go
+++ b/types/twt.go
@@ -143,7 +143,7 @@ func (twt Twt) Hash() string {
 		return twt.hash
 	}
 
-	payload := twt.Twter.URL + "\n" + twt.Created.String() + "\n" + twt.Text
+	payload := twt.Twter.URL + "\n" + twt.Created.Format(time.RFC3339) + "\n" + twt.Text
 	sum := blake2b.Sum256([]byte(payload))
 
 	// Base32 is URL-safe, unlike Base64, and shorter than hex.

--- a/types/twt_test.go
+++ b/types/twt_test.go
@@ -84,3 +84,43 @@ func TestSubject(t *testing.T) {
 		})
 	}
 }
+
+func TestHash(t *testing.T) {
+	assert := assert.New(t)
+
+	CET := time.FixedZone("UTC+1", 1 * 60 * 60)
+	testCases := []struct {
+		name     string
+		created  time.Time
+		expected string
+	}{
+		{
+			name:     "timestamp with milliseconds precision is truncated to seconds precision",
+			created:  time.Date(2020, 12, 9, 16, 38, 42, 123_000_000, CET),
+			expected: "64u2m5a",
+		}, {
+			name:     "timestamp with seconds precision and UTC+1 offset is kept intact",
+			created:  time.Date(2020, 12, 9, 16, 38, 42, 0, CET),
+			expected: "64u2m5a",
+		}, {
+			name:     "timestamp with minutes precision is expanded to seconds precision",
+			created:  time.Date(2020, 12, 9, 16, 38, 0, 0, CET),
+			expected: "a3c3k5q",
+		}, {
+			name:     "timestamp with UTC is rendered as designated Zulu offset rather than numeric offset",
+			created:  time.Date(2020, 12, 9, 15, 38, 42, 0, time.UTC),
+			expected: "74qtyjq",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			twt := Twt{
+					Twter:   Twter{URL: "https://example.com/twtxt.txt"},
+					Text:    "The twt hash now uses the RFC 3339 timestamp format.",
+					Created: testCase.created,
+			}
+			assert.Equal(testCase.expected, twt.Hash())
+		})
+	}
+}

--- a/types/twt_test.go
+++ b/types/twt_test.go
@@ -99,6 +99,10 @@ func TestHash(t *testing.T) {
 			created:  time.Date(2020, 12, 9, 16, 38, 42, 123_000_000, CET),
 			expected: "64u2m5a",
 		}, {
+			name:     "timestamp with milliseconds precision is truncated to seconds precision without rounding",
+			created:  time.Date(2020, 12, 9, 16, 38, 42, 999_000_000, CET),
+			expected: "64u2m5a",
+		}, {
 			name:     "timestamp with seconds precision and UTC+1 offset is kept intact",
 			created:  time.Date(2020, 12, 9, 16, 38, 42, 0, CET),
 			expected: "64u2m5a",


### PR DESCRIPTION
This fixes #286.

##### Component Name

Twt type

##### Test Plan

I've introduced some tests to verify the changed behavior. Unfortunately I wasn't able to reuse the already existing `ParseTimestamp(…)` function in the `internal` package because of cyclic dependencies without refactoring the code. That function would have made the timestamps in the tests more readable and also enabled me to cover more things like the fact that missing time zone information are treated as UTC, too.

##### Additional Information

I'd like to add some more formal documentation on how the twt hash algorithm now works. [Your blog post](https://twtxt.net/blog/prologic/2020/10/18/making-twtxt-better#subject-and-conversations) is now partially outdated. ;-) The **exact** timestamp format is not super obvious, e.g. Go formats UTC always as `Z` instead of `+00:00` in `time.RFC3339` format. This is also true for [`-00:00`](https://tools.ietf.org/html/rfc3339#section-4.3) and missing time zones as mentioned above. Let's don't make people to re-reverse-engineer the fine details.

There's the _docs/_ directory where I reckon is a good place to document this. Unfortunately, I was not able to tell what static site generator this is all managed by. I think a new post is need to cover the twt hash extension. What do you think?

For code formatting I tried to orient myself by already existing code. Let me know, where I messed up.