### PR TITLE
Fix external domain

### DIFF
--- a/internal/static/css/99-twtxt.css
+++ b/internal/static/css/99-twtxt.css
@@ -235,6 +235,7 @@ video {
   font-weight: 100;
   color: var(--muted-text);
   margin-top: 18px;
+  white-space: nowrap;
 }
 
 .author {
@@ -375,10 +376,7 @@ footer small .footer-menu a:last-child::after{
 
   /* Name off timeline author */
   .u-author.h-card{
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: flex-start;
+    display: inline;
     margin-bottom: 10px;
   }
   .u-author.h-card>div{


### PR DESCRIPTION
This PR fixes the external profile page, when showing a domain, to wrap to the next line if it's too big.

![image](https://user-images.githubusercontent.com/5929807/101966969-896e4200-3c65-11eb-823e-7a65b3db9a07.png)

![image](https://user-images.githubusercontent.com/5929807/101966977-955a0400-3c65-11eb-98c2-b25499469483.png)
