### PR TITLE
 testing releasers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,20 +18,30 @@ jobs:
               sudo apt-get update &&
               sudo apt-get install -y libavcodec-dev
               libavutil-dev libavformat-dev libswscale-dev
+            releaser: .goreleaser-linux.yml
+
           - platform: macos-latest
-            pre: brew install ffmpeg
+            pre: brew install ffmpeg goreleaser
+            releaser: .goreleaser-darwin.yml
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install dependencies
         run: /bin/sh -c "${{ matrix.pre }}"
+
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
         with:
           go-version: ${{ matrix.go-version }}
         id: go
+
       - name: Checkout
         uses: actions/checkout@v1
+
       - name: Build
         run: go build -v ./cmd/twtd/...
+
       - name: Test
         run: go test -v -race ./...
+
+      - name: Go Releaser
+        run:  curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh && ./bin/goreleaser build --skip-validate --config ${{ matrix.releaser }}

--- a/.goreleaser-darwin.yml
+++ b/.goreleaser-darwin.yml
@@ -1,0 +1,34 @@
+---
+builds:
+  - id: twt
+    binary: twt
+    main: ./cmd/twt
+    flags: -tags "static_build"
+    ldflags: >-
+      -w
+      -X github.com/jointwt/twtxt.Version={{.Version}}
+      -X github.com/jointwt/twtxt.Commit={{.Commit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - windows
+    goarch:
+      - amd64
+
+signs:
+  - artifacts: checksum
+brews:
+  -
+    github:
+      owner: prologic
+      name: homebrew-twtxt
+    homepage: "https://github.io/jointwt/twtxt"
+    description: |
+      📕 twtxt is a Self-Hosted, Twitter™-like Decentralised microBlogging
+      platform. No ads, no tracking, your content, your data!
+release:
+  github:
+    owner: prologic
+    name: twtxt
+  draft: true

--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -1,0 +1,35 @@
+---
+builds:
+  - id: twt
+    binary: twt
+    main: ./cmd/twt
+    flags: -tags "static_build"
+    ldflags: >-
+      -w
+      -X github.com/jointwt/twtxt.Version={{.Version}}
+      -X github.com/jointwt/twtxt.Commit={{.Commit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+    goarm:
+      - 6
+      - 7
+signs:
+  - artifacts: checksum
+brews:
+  -
+    github:
+      owner: prologic
+      name: homebrew-twtxt
+    homepage: "https://github.io/jointwt/twtxt"
+    description: |
+      📕 twtxt is a Self-Hosted, Twitter™-like Decentralised microBlogging
+      platform. No ads, no tracking, your content, your data!
+release:
+  github:
+    owner: prologic
+    name: twtxt
+  draft: true


### PR DESCRIPTION
##### Summary

Fix goreleaser by spliting into separate release paths.

The "Dar-Win" will do macos and windows. the Linux will do linux.

This should get up and going for the major platforms.. PRs are welcome to expand. :)

##### Component Name

##### Test Plan

##### Additional Information
