### PR TITLE
Fix tag expansion

### DIFF
--- a/internal/twt.go
+++ b/internal/twt.go
@@ -56,8 +56,8 @@ func ExpandMentions(conf *Config, db Store, user *User, text string) string {
 	})
 }
 
-// Turns #tag into "@<tag URL>"
-func ExpandTag(conf *Config, db Store, user *User, text string) string {
+// Turns #tag into "#<tag URL>"
+func ExpandTag(conf *Config, text string) string {
 	re := regexp.MustCompile(`#([-\w]+)`)
 	return re.ReplaceAllStringFunc(text, func(match string) string {
 		parts := re.FindStringSubmatch(match)
@@ -127,7 +127,7 @@ func AppendTwt(conf *Config, db Store, user *User, text string, args ...interfac
 	line := fmt.Sprintf(
 		"%s\t%s\n",
 		now.Format(time.RFC3339),
-		ExpandTag(conf, db, user, ExpandMentions(conf, db, user, text)),
+		ExpandTag(conf, ExpandMentions(conf, db, user, text)),
 	)
 
 	if _, err = f.WriteString(line); err != nil {

--- a/internal/twt.go
+++ b/internal/twt.go
@@ -60,11 +60,11 @@ func ExpandMentions(conf *Config, db Store, user *User, text string) string {
 func ExpandTag(conf *Config, text string) string {
 	// Sadly, Go's regular expressions don't support negative lookbehind, so we
 	// need to bake it differently into the regex with several choices.
-	re := regexp.MustCompile(`(^|\s|\()#([-\w]+)`)
+	re := regexp.MustCompile(`(^|\s|(^|[^\]])\()#([-\w]+)`)
 	return re.ReplaceAllStringFunc(text, func(match string) string {
 		parts := re.FindStringSubmatch(match)
 		prefix := parts[1];
-		tag := parts[2]
+		tag := parts[3]
 
 		return fmt.Sprintf("%s#<%s %s>", prefix, tag, URLForTag(conf.BaseURL, tag))
 	})

--- a/internal/twt.go
+++ b/internal/twt.go
@@ -58,12 +58,15 @@ func ExpandMentions(conf *Config, db Store, user *User, text string) string {
 
 // Turns #tag into "#<tag URL>"
 func ExpandTag(conf *Config, text string) string {
-	re := regexp.MustCompile(`#([-\w]+)`)
+	// Sadly, Go's regular expressions don't support negative lookbehind, so we
+	// need to bake it differently into the regex with several choices.
+	re := regexp.MustCompile(`(^|\s|\()#([-\w]+)`)
 	return re.ReplaceAllStringFunc(text, func(match string) string {
 		parts := re.FindStringSubmatch(match)
-		tag := parts[1]
+		prefix := parts[1];
+		tag := parts[2]
 
-		return fmt.Sprintf("#<%s %s>", tag, URLForTag(conf.BaseURL, tag))
+		return fmt.Sprintf("%s#<%s %s>", prefix, tag, URLForTag(conf.BaseURL, tag))
 	})
 }
 

--- a/internal/twt_test.go
+++ b/internal/twt_test.go
@@ -28,9 +28,21 @@ func TestExpandTag(t *testing.T) {
 			input:    "#foo",
 			expected: "#<foo http://0.0.0.0:8000/search?tag=foo>",
 		}, {
+			name:     "expands a folded tag preceded by a space",
+			input:    " #bar",
+			expected: " #<bar http://0.0.0.0:8000/search?tag=bar>",
+		}, {
 			name:     "expands a folded tag surrounded with spaces",
 			input:    "foo #bar baz",
 			expected: "foo #<bar http://0.0.0.0:8000/search?tag=bar> baz",
+		}, {
+			name:     "expands a folded tag preceded by a parenthesis",
+			input:    "(#bar) baz",
+			expected: "(#<bar http://0.0.0.0:8000/search?tag=bar>) baz",
+		}, {
+			name:     "expands a folded tag preceded by a space with parenthesis",
+			input:    " (#bar) baz",
+			expected: " (#<bar http://0.0.0.0:8000/search?tag=bar>) baz",
 		}, {
 			name:     "expands a folded tag in enclosed in parentheses",
 			input:    "foo (#bar) baz",
@@ -59,6 +71,13 @@ func TestExpandTag(t *testing.T) {
 			name:     "does nothing with a markdown link title/URL containing an anchor",
 			input:    "[#bar](https://example.com/foo#bar)",
 			expected: "[#bar](https://example.com/foo#bar)",
+		}, {
+			// URLs starting with anchors are probably very rarely or even
+			// never used, since they're relative URLs and there's no spec on
+			// how to make them absolute in context of twts.
+			name:     "does nothing with a markdown URL starting with an anchor",
+			input:    "[bar](#foo)",
+			expected: "[bar](#foo)",
 		},
 	}
 

--- a/internal/twt_test.go
+++ b/internal/twt_test.go
@@ -1,0 +1,54 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandTag(t *testing.T) {
+	assert := assert.New(t)
+	conf := &Config{BaseURL: "http://0.0.0.0:8000"}
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "does nothing with an empty text",
+			input:    "",
+			expected: "",
+		}, {
+			name:     "does nothing with a text without any tag",
+			input:    "just regular text",
+			expected: "just regular text",
+		}, {
+			name:     "expands a folded tag",
+			input:    "#foo",
+			expected: "#<foo http://0.0.0.0:8000/search?tag=foo>",
+		}, {
+			name:     "expands a folded tag surrounded with spaces",
+			input:    "foo #bar baz",
+			expected: "foo #<bar http://0.0.0.0:8000/search?tag=bar> baz",
+		}, {
+			name:     "expands a folded tag in enclosed in parentheses",
+			input:    "foo (#bar) baz",
+			expected: "foo (#<bar http://0.0.0.0:8000/search?tag=bar>) baz",
+		}, {
+			name:     "does nothing with an already expanded tag pointing to local instance",
+			input:    "#<foo http://0.0.0.0:8000/search?tag=foo>",
+			expected: "#<foo http://0.0.0.0:8000/search?tag=foo>",
+		}, {
+			name:     "does nothing with an already expanded tag pointing somewhere else",
+			input:    "#<foo https://example.com/foo>",
+			expected: "#<foo https://example.com/foo>",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(testCase.expected, ExpandTag(conf, testCase.input))
+		})
+	}
+}

--- a/internal/twt_test.go
+++ b/internal/twt_test.go
@@ -43,6 +43,22 @@ func TestExpandTag(t *testing.T) {
 			name:     "does nothing with an already expanded tag pointing somewhere else",
 			input:    "#<foo https://example.com/foo>",
 			expected: "#<foo https://example.com/foo>",
+		}, {
+			name:     "does nothing with a plain URL containing an anchor",
+			input:    "https://example.com/foo#bar",
+			expected: "https://example.com/foo#bar",
+		}, {
+			name:     "does nothing with a markdown link URL containing an anchor",
+			input:    "[foo](https://example.com/foo#bar)",
+			expected: "[foo](https://example.com/foo#bar)",
+		}, {
+			name:     "does nothing with a markdown link title containing an anchor",
+			input:    "[#bar](https://example.com/foo)",
+			expected: "[#bar](https://example.com/foo)",
+		}, {
+			name:     "does nothing with a markdown link title/URL containing an anchor",
+			input:    "[#bar](https://example.com/foo#bar)",
+			expected: "[#bar](https://example.com/foo#bar)",
 		},
 	}
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1644,7 +1644,7 @@ func FormatTwtFactory(conf *Config) func(text string) template.HTML {
 		// renderer can interpreter newlines as `<br />` and `<p>`.
 		text = strings.ReplaceAll(text, "\u2028", "\n")
 		// Replace simple '#just-tag' entrys with local link
-		text = ExpandTag(conf, nil, nil, text)
+		text = ExpandTag(conf, text)
 		extensions := parser.CommonExtensions | parser.HardLineBreak | parser.NoEmptyLineBeforeBlock
 		mdParser := parser.NewWithExtensions(extensions)
 


### PR DESCRIPTION
This PR fixes some common cases where hashes (`#`) were wrongly recognized as hash tags to be expanded, namely when actually being the anchor parts in URLs, #300. I'm pretty sure there are scenarios left where hashes are still expanded to hash tags where in fact they shouldn't have been and the other way around as well. I tried to use as little context as possible to keep the regex halfway readable, but this also means that it recognizes e.g. `foo ](#bar` as a Markdown link and does nothing, where in fact it could have actually expanded the `#bar` to a hash tag, because it's actually not a link. Since this probably won't happen anyways, I didn't bother too much.

Once @JonLundy's twt tokenizer is ready, this function should definitely be rewritten to reuse the tokenizer and do its job properly. But for now, this might do it. A lot of – if not most – real world cases are covered by this partial fix.