### PR TITLE
Fix public following disclosure

### DIFF
--- a/internal/jobs.go
+++ b/internal/jobs.go
@@ -172,7 +172,7 @@ func (job *UpdateFeedsJob) Run() {
 	log.Infof("updating feeds for %d users and  %d feeds", len(users), len(feeds))
 
 	sources := make(types.Feeds)
-	followers := make(map[types.Feed][]string)
+	publicFollowers := make(map[types.Feed][]string)
 
 	// Ensure all specialUsername feeds are in the cache
 	for _, username := range specialUsernames {
@@ -192,12 +192,14 @@ func (job *UpdateFeedsJob) Run() {
 	for _, user := range users {
 		for feed := range user.Sources() {
 			sources[feed] = true
-			followers[feed] = append(followers[feed], user.Username)
+			if user.IsFollowingPubliclyVisible {
+				publicFollowers[feed] = append(publicFollowers[feed], user.Username)
+			}
 		}
 	}
 
 	log.Infof("updating %d sources", len(sources))
-	job.cache.FetchTwts(job.conf, job.archive, sources, followers)
+	job.cache.FetchTwts(job.conf, job.archive, sources, publicFollowers)
 
 	log.Infof("warming cache with local twts for %s", job.conf.BaseURL)
 	job.cache.GetByPrefix(job.conf.BaseURL, true)

--- a/internal/whofollows_handler.go
+++ b/internal/whofollows_handler.go
@@ -61,7 +61,7 @@ func (s *Server) WhoFollowsHandler() httprouter.Handle {
 
 		nick := ""
 		for _, user := range users {
-			if !user.IsFollowersPubliclyVisible && !ctx.User.Is(user.URL) {
+			if !user.IsFollowingPubliclyVisible && !ctx.User.Is(user.URL) {
 				continue
 			}
 


### PR DESCRIPTION
* Fix following disclosure bug in Who Follows Resource

  The "Show my followers publicly" on the user setting page controls whether to display all the people who are following me and maps to `User.IsFollowersPubliclyVisible`.

  The "Show my followings publicly" on the user setting page controls whether to disclose my identity to all the people I follow and also if other people can publicly see all my subscriptions on my profile. It maps to `User.IsFollowingPubliclyVisible`.

  This commit fixes a bug where the wrong user setting had been checked (notice the difference in `…ing…` vs. `…ers…`) when deciding to include a certain user in the Who Follows Resource.

  Users who had disabled both settings were not affected by this privacy bug.

* Fix following disclosure bug in User-Agent

  Previously all followers were included in the User-Agent string, even if they had opted out in their privacy settings. At least they were included in the total number of followers in the Who Follows Resource URL.

  The cache is the only one where the `followers` (now `publicFollowers`) map was non-`nil`.

I tested twtd locally with different combinations of those two settings and several different accounts, so my test cases all result in the correct `User-Agent` being produced (as verified in my Nginx access log):

1. no public followers: default `twtxt/0.1.0@ce0e87a (Pod: twtxt.net Support: http://0.0.0.0:8000/support)` (I just run `make dev`, so the default pod name is not overridden)
2. a single public follower: `twtxt/0.1.0@ce0e87a (+http://0.0.0.0:8000/user/g1/twtxt.txt; @g1)`
3. two and more public followers: `twtxt/0.1.0@9633bcb (~http://0.0.0.0:8000/whoFollows?followers=2&token=xbBrulT0Q; contact=http://0.0.0.0:8000/support)`

The Who Follows Resource now only includes the ones who have activated the "Show my followings publicly".