### PR TITLE
feat: add ReadPreambleFeed

### DIFF
--- a/internal/bookmark_handlers.go
+++ b/internal/bookmark_handlers.go
@@ -55,7 +55,7 @@ func (s *Server) BookmarkHandler() httprouter.Handle {
 		if r.Header.Get("Accept") == "application/json" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"success": true}`))
+			_,_=w.Write([]byte(`{"success": true}`))
 			return
 		}
 

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -72,7 +72,7 @@ func (s *Server) PageHandler(name string) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		ctx := NewContext(s.config, s.db, r)
 
-		md, err := RenderString(mdTpl, ctx)
+		md, err := RenderHTML(mdTpl, ctx)
 		if err != nil {
 			log.WithError(err).Errorf("error rendering page %s", name)
 			ctx.Error = true

--- a/internal/robots.go
+++ b/internal/robots.go
@@ -30,7 +30,7 @@ func (s *Server) RobotsHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		ctx := NewContext(s.config, s.db, r)
 
-		text, err := RenderString(robotsTpl, ctx)
+		text, err := RenderPlainText(robotsTpl, ctx)
 		if err != nil {
 			log.WithError(err).Errorf("error rendering robots.txt")
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/twtxt_handlers.go
+++ b/internal/twtxt_handlers.go
@@ -179,7 +179,7 @@ func (s *Server) TwtxtHandler() httprouter.Handle {
 			preampleTemplate = defaultPreambleTemplate
 		}
 
-		preamble, err := RenderString(preampleTemplate, ctx)
+		preamble, err := RenderPlainText(preampleTemplate, ctx)
 		if err != nil {
 			log.WithError(err).Warn("error rendering twtxt preamble")
 		}

--- a/internal/twtxt_handlers.go
+++ b/internal/twtxt_handlers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/jointwt/twtxt/types"
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
 )
@@ -145,25 +146,6 @@ func (s *Server) TwtxtHandler() httprouter.Handle {
 			log.WithError(err).Warnf("unable to load user or feed profile for %s", nick)
 		}
 
-		var preampleTemplate string
-
-		preampleCustomTemplateFn := filepath.Join(s.config.Data, feedsDir, fmt.Sprintf("%s.tpl", nick))
-		if FileExists(preampleCustomTemplateFn) {
-			if data, err := ioutil.ReadFile(preampleCustomTemplateFn); err == nil {
-				preampleTemplate = string(data)
-			} else {
-				log.WithError(err).Warnf("error loading custom preamble template for %s")
-				preampleTemplate = defaultPreambleTemplate
-			}
-		} else {
-			preampleTemplate = defaultPreambleTemplate
-		}
-
-		preamble, err := RenderString(preampleTemplate, ctx)
-		if err != nil {
-			log.WithError(err).Warn("error rendering twtxt preamble")
-		}
-
 		f, err := os.Open(fn)
 		if err != nil {
 			log.WithError(err).Error("error opening feed")
@@ -171,6 +153,36 @@ func (s *Server) TwtxtHandler() httprouter.Handle {
 			return
 		}
 		defer f.Close()
+
+		pr, err := types.ReadPreambleFeed(f)
+		if err != nil {
+			log.WithError(err).Error("error reading feed")
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		preampleTemplate := pr.Preamble()
+
+		if preampleTemplate == "" {
+			preampleCustomTemplateFn := filepath.Join(s.config.Data, feedsDir, fmt.Sprintf("%s.tpl", nick))
+			if FileExists(preampleCustomTemplateFn) {
+				if data, err := ioutil.ReadFile(preampleCustomTemplateFn); err == nil {
+					preampleTemplate = string(data)
+				} else {
+					log.WithError(err).Warnf("error loading custom preamble template for %s", nick)
+					preampleTemplate = defaultPreambleTemplate
+				}
+			}
+		}
+
+		if preampleTemplate == "" {
+			preampleTemplate = defaultPreambleTemplate
+		}
+
+		preamble, err := RenderString(preampleTemplate, ctx)
+		if err != nil {
+			log.WithError(err).Warn("error rendering twtxt preamble")
+		}
 
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", int64(len(preamble))+fileInfo.Size()))
@@ -184,6 +196,6 @@ func (s *Server) TwtxtHandler() httprouter.Handle {
 		if _, err = w.Write([]byte(preamble)); err != nil {
 			log.WithError(err).Warn("error writing twtxt preamble")
 		}
-		_, _ = io.Copy(w, f)
+		_, _ = io.Copy(w, pr)
 	}
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	text_template "text/template"
 	"time"
 
 	// Blank import so we can handle image/jpeg
@@ -380,9 +381,21 @@ func RunCmd(timeout time.Duration, command string, args ...string) error {
 	return nil
 }
 
-// RenderString ...
-func RenderString(tpl string, ctx *Context) (string, error) {
+// RenderHTML ...
+func RenderHTML(tpl string, ctx *Context) (string, error) {
 	t := template.Must(template.New("tpl").Parse(tpl))
+	buf := bytes.NewBuffer([]byte{})
+	err := t.Execute(buf, ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// RenderPlainText ...
+func RenderPlainText(tpl string, ctx *Context) (string, error) {
+	t := text_template.Must(text_template.New("tpl").Parse(tpl))
 	buf := bytes.NewBuffer([]byte{})
 	err := t.Execute(buf, ctx)
 	if err != nil {


### PR DESCRIPTION
Read the template out of a users feed and pass the remainder to output. :)

If it starts with a # it will attempt to read out the preamble from the feed till it finds a blank line. 

```
# SO PREAMBLE TEMPLATE
# GOES HERE
{with template}
# STUFF
{end}

2021-... twts continue here
```

will return a special reader that pulls out the stuff before as a string to feed into the template parser. and the remainder of the file can be read out with copy as normal. 