### PR TITLE
Fix ignore preamble read errors and use default preamble tempalte

### DIFF
--- a/internal/twtxt_handlers.go
+++ b/internal/twtxt_handlers.go
@@ -161,6 +161,9 @@ func (s *Server) TwtxtHandler() httprouter.Handle {
 			preampleTemplate = pr.Preamble()
 		} else {
 			log.WithError(err).Warn("error reading feed preamble")
+			if _, err := f.Seek(0, io.SeekStart); err != nil {
+				log.WithError(err).Warn("error seeking feed")
+			}
 		}
 
 		if preampleTemplate == "" {

--- a/internal/twtxt_handlers.go
+++ b/internal/twtxt_handlers.go
@@ -154,14 +154,14 @@ func (s *Server) TwtxtHandler() httprouter.Handle {
 		}
 		defer f.Close()
 
-		pr, err := types.ReadPreambleFeed(f)
-		if err != nil {
-			log.WithError(err).Error("error reading feed")
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
+		var preampleTemplate string
 
-		preampleTemplate := pr.Preamble()
+		pr, err := types.ReadPreambleFeed(f)
+		if err == nil {
+			preampleTemplate = pr.Preamble()
+		} else {
+			log.WithError(err).Warn("error reading feed preamble")
+		}
 
 		if preampleTemplate == "" {
 			preampleCustomTemplateFn := filepath.Join(s.config.Data, feedsDir, fmt.Sprintf("%s.tpl", nick))


### PR DESCRIPTION
Seeing a lot of 500(s) on my pod through Grafana.

I think we should just ignore any errors _trying_ to read a feed's
preamble (_if one exists at all_) and default to the default template.