### PR TITLE
Cleanup code

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -525,11 +525,7 @@ func IsImage(fn string) bool {
 		return false
 	}
 
-	if filetype.IsImage(head) {
-		return true
-	}
-
-	return false
+	return filetype.IsImage(head)
 }
 
 func IsAudio(fn string) bool {
@@ -546,11 +542,7 @@ func IsAudio(fn string) bool {
 		return false
 	}
 
-	if filetype.IsAudio(head) {
-		return true
-	}
-
-	return false
+	return filetype.IsAudio(head)
 }
 
 func IsVideo(fn string) bool {
@@ -567,11 +559,7 @@ func IsVideo(fn string) bool {
 		return false
 	}
 
-	if filetype.IsVideo(head) {
-		return true
-	}
-
-	return false
+	return filetype.IsVideo(head)
 }
 
 type ImageOptions struct {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -608,7 +608,7 @@ func DownloadImage(conf *Config, url string, resource, name string, opts *ImageO
 	defer tf.Close()
 
 	if _, err := io.Copy(tf, res.Body); err != nil {
-		log.WithError(err).Error("error writng temporary file")
+		log.WithError(err).Error("error writing temporary file")
 		return "", err
 	}
 
@@ -637,7 +637,7 @@ func ReceiveAudio(r io.Reader) (string, error) {
 	}
 
 	if _, err := io.Copy(tf, r); err != nil {
-		log.WithError(err).Error("error writng temporary file")
+		log.WithError(err).Error("error writing temporary file")
 		return "", err
 	}
 
@@ -661,7 +661,7 @@ func ReceiveImage(r io.Reader) (string, error) {
 	}
 
 	if _, err := io.Copy(tf, r); err != nil {
-		log.WithError(err).Error("error writng temporary file")
+		log.WithError(err).Error("error writing temporary file")
 		return "", err
 	}
 
@@ -685,7 +685,7 @@ func ReceiveVideo(r io.Reader) (string, error) {
 	}
 
 	if _, err := io.Copy(tf, r); err != nil {
-		log.WithError(err).Error("error writng temporary file")
+		log.WithError(err).Error("error writing temporary file")
 		return "", err
 	}
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -588,20 +588,11 @@ func DownloadImage(conf *Config, url string, resource, name string, opts *ImageO
 	}
 	defer res.Body.Close()
 
-	tf, err := ioutil.TempFile("", "rss2twtxt-*")
+	tf, err := receiveFile(res.Body, "rss2twtxt-*")
+	if tf != nil {
+		defer tf.Close()
+	}
 	if err != nil {
-		log.WithError(err).Error("error creating temporary file")
-		return "", err
-	}
-	defer tf.Close()
-
-	if _, err := io.Copy(tf, res.Body); err != nil {
-		log.WithError(err).Error("error writing temporary file")
-		return "", err
-	}
-
-	if _, err := tf.Seek(0, io.SeekStart); err != nil {
-		log.WithError(err).Error("error seeking temporary file")
 		return "", err
 	}
 
@@ -618,19 +609,8 @@ func DownloadImage(conf *Config, url string, resource, name string, opts *ImageO
 }
 
 func ReceiveAudio(r io.Reader) (string, error) {
-	tf, err := ioutil.TempFile("", "twtxt-upload-*")
+	tf, err := receiveFile(r, "twtxt-upload-*")
 	if err != nil {
-		log.WithError(err).Error("error creating temporary file")
-		return "", err
-	}
-
-	if _, err := io.Copy(tf, r); err != nil {
-		log.WithError(err).Error("error writing temporary file")
-		return "", err
-	}
-
-	if _, err := tf.Seek(0, io.SeekStart); err != nil {
-		log.WithError(err).Error("error seeking temporary file")
 		return "", err
 	}
 
@@ -642,19 +622,8 @@ func ReceiveAudio(r io.Reader) (string, error) {
 }
 
 func ReceiveImage(r io.Reader) (string, error) {
-	tf, err := ioutil.TempFile("", "twtxt-upload-*")
+	tf, err := receiveFile(r, "twtxt-upload-*")
 	if err != nil {
-		log.WithError(err).Error("error creating temporary file")
-		return "", err
-	}
-
-	if _, err := io.Copy(tf, r); err != nil {
-		log.WithError(err).Error("error writing temporary file")
-		return "", err
-	}
-
-	if _, err := tf.Seek(0, io.SeekStart); err != nil {
-		log.WithError(err).Error("error seeking temporary file")
 		return "", err
 	}
 
@@ -666,19 +635,8 @@ func ReceiveImage(r io.Reader) (string, error) {
 }
 
 func ReceiveVideo(r io.Reader) (string, error) {
-	tf, err := ioutil.TempFile("", "twtxt-upload-*")
+	tf, err := receiveFile(r, "twtxt-upload-*")
 	if err != nil {
-		log.WithError(err).Error("error creating temporary file")
-		return "", err
-	}
-
-	if _, err := io.Copy(tf, r); err != nil {
-		log.WithError(err).Error("error writing temporary file")
-		return "", err
-	}
-
-	if _, err := tf.Seek(0, io.SeekStart); err != nil {
-		log.WithError(err).Error("error seeking temporary file")
 		return "", err
 	}
 
@@ -687,6 +645,26 @@ func ReceiveVideo(r io.Reader) (string, error) {
 	}
 
 	return tf.Name(), nil
+}
+
+func receiveFile(r io.Reader, filePattern string) (*os.File, error) {
+	tf, err := ioutil.TempFile("", filePattern)
+	if err != nil {
+		log.WithError(err).Error("error creating temporary file")
+		return nil, err
+	}
+
+	if _, err := io.Copy(tf, r); err != nil {
+		log.WithError(err).Error("error writing temporary file")
+		return tf, err
+	}
+
+	if _, err := tf.Seek(0, io.SeekStart); err != nil {
+		log.WithError(err).Error("error seeking temporary file")
+		return tf, err
+	}
+
+	return tf, nil
 }
 
 func TranscodeAudio(conf *Config, ifn string, resource, name string, opts *AudioOptions) (string, error) {


### PR DESCRIPTION
When I had a look at the image processing code, I noticed a few imperfections. I tested my changes locally and verified by uploading an avatar and images. This pull request is probably best viewed in the side by side diff, since the diff looks a bit weird with its method-interleaved changes rendering. :-/

As written in the commit message of my third commit, I don't understand why we don't need to close the temporary file in the `Receive*(…)` cases. It seems that it's working without an explicit call to `Close()` and `lsof` does not report open files.